### PR TITLE
Download multiple media files without archiving

### DIFF
--- a/assets/js/hooks/chat.js
+++ b/assets/js/hooks/chat.js
@@ -17,17 +17,38 @@ export const hooks = {
     this.el.addEventListener("chat:download-messages", e => {
       const checkboxes = document.querySelectorAll(".selectCheckbox.checked");
       const messages = [];
+      const mediaTypes = ["file", "image", "video"];
+
+      let nonMedia = false;
+
       for (const checkbox of checkboxes) {
         const message = checkbox.parentNode;
+
         if (message.classList.contains("hidden") == false) {
           messages.push({
             id: message.getAttribute("phx-value-id"),
             index: message.getAttribute("phx-value-index")
           });
         }
+
+        if (!mediaTypes.includes(message.dataset.type)) {
+          nonMedia = true
+        }
       }
 
-      this.pushEvent(`${e.detail.chatType}/download-messages`, { messages: JSON.stringify(messages) })
+      if (nonMedia) {
+        this.pushEvent(`${e.detail.chatType}/download-messages`, { messages: JSON.stringify(messages) })
+      } else {
+        let timeout = 0;
+
+        for (const message of messages) {
+          setTimeout(() => {
+            this.pushEvent(`${e.detail.chatType}/message/download`, message)
+          }, timeout)
+
+          timeout += 1000
+        }
+      }
     })
 
     this.el.addEventListener("chat:toggle-selection-mode", e => {

--- a/lib/chat_web/live/main_live/layout/message.ex
+++ b/lib/chat_web/live/main_live/layout/message.ex
@@ -54,7 +54,7 @@ defmodule ChatWeb.MainLive.Layout.Message do
       end)
 
     ~H"""
-    <div class="messageBlock flex flex-row px-2 sm:px-8" id={"message-block-#{@msg.id}"} {@dynamic_attrs}>
+    <div class="messageBlock flex flex-row px-2 sm:px-8" id={"message-block-#{@msg.id}"} data-type={@msg.type} {@dynamic_attrs}>
       <div class={"m-1 w-full flex " <> if(@is_mine?, do: "justify-end t-#{@chat_type}-mine-message x-mine", else: "justify-start x-peer")} id={"#{@chat_type}-message-#{@msg.id}"}>
         <.message
           author={@author}


### PR DESCRIPTION
Quick solution for downloading multiple files without zipping, in case the selected messages are files, images, and/or videos.
A more robust solution might be required in which case I'll need to refactor this. That would involve more client-to-server communication.

Resolves #65.