### PR TITLE
Fix formatting

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,5 +1,5 @@
 [
   import_deps: [:phoenix],
-  inputs: ["*.{ex,exs}", "{config,lib,test}/**/*.{ex,exs}"],
-  formatters: [Phoenix.LiveView.HTMLFormatter]
+  inputs: ["*.{heex,ex,exs}", "{config,lib,test}/**/*.{heex,ex,exs}"],
+  plugins: [Phoenix.LiveView.HTMLFormatter]
 ]

--- a/lib/chat_web/live/live_helpers.ex
+++ b/lib/chat_web/live/live_helpers.ex
@@ -27,7 +27,12 @@ defmodule ChatWeb.LiveHelpers do
     assigns = assign_new(assigns, :hide_event, fn -> assigns[:hide_event] end)
 
     ~H"""
-    <div id={@id} class="phx-modal fade-in" phx-remove={hide_modal(@id, @hide_event)} style="display: none;">
+    <div
+      id={@id}
+      class="phx-modal fade-in"
+      phx-remove={hide_modal(@id, @hide_event)}
+      style="display: none;"
+    >
       <div
         id={@id <> "-content"}
         class={"phx-modal-content border-0 rounded-lg bg-white p-4 fade-in-scale flex flex-col #{@class} t-modal"}
@@ -36,8 +41,13 @@ defmodule ChatWeb.LiveHelpers do
         phx-key="escape"
         style="display: none;"
       >
-        <a id={@id <> "-close"} href="#" class="phx-modal-close w-full flex flex-row justify-end" phx-click={hide_modal(@id, @hide_event)}>
-          <.icon id="close" class="w-4 h-4 flex fill-grayscale t-close-popup"/>
+        <a
+          id={@id <> "-close"}
+          href="#"
+          class="phx-modal-close w-full flex flex-row justify-end"
+          phx-click={hide_modal(@id, @hide_event)}
+        >
+          <.icon id="close" class="w-4 h-4 flex fill-grayscale t-close-popup" />
         </a>
 
         <%= render_slot(@inner_block) %>
@@ -88,16 +98,16 @@ defmodule ChatWeb.LiveHelpers do
 
   def dropdown(assigns) do
     ~H"""
-      <div
-        id={@id}
-        class="dropdown t-dropdown"
-        phx-click-away={JS.hide(transition: "fade-out", to: "#" <> @id)}
-        phx-window-keydown={JS.hide(transition: "fade-out", to: "#" <> @id)}
-        phx-key="escape"
-        style="display: none;"
-      >
-        <%= render_slot(@inner_block) %>
-      </div>
+    <div
+      id={@id}
+      class="dropdown t-dropdown"
+      phx-click-away={JS.hide(transition: "fade-out", to: "#" <> @id)}
+      phx-window-keydown={JS.hide(transition: "fade-out", to: "#" <> @id)}
+      phx-key="escape"
+      style="display: none;"
+    >
+      <%= render_slot(@inner_block) %>
+    </div>
     """
   end
 

--- a/lib/chat_web/live/main_live/index.ex
+++ b/lib/chat_web/live/main_live/index.ex
@@ -331,9 +331,14 @@ defmodule ChatWeb.MainLive.Index do
 
   defp flash_notification(assigns) do
     ~H"""
-    <div id={@id} class={"flex items-center t-inv-sent justify-between w-screen sm:w-96 min-h-fit z-30 bg-green-400 rounded-lg text-teal-900 px-4 py-3 shadow-md centered"} role="alert" style="display: none;">
+    <div
+      id={@id}
+      class="flex items-center t-inv-sent justify-between w-screen sm:w-96 min-h-fit z-30 bg-green-400 rounded-lg text-teal-900 px-4 py-3 shadow-md centered"
+      role="alert"
+      style="display: none;"
+    >
       <div class="flex items-center">
-        <.icon id="checked" class="w-5 h-5 fill-white"/>
+        <.icon id="checked" class="w-5 h-5 fill-white" />
         <p class="ml-2 text-white">Invitation Sent!</p>
       </div>
       <div phx-click={JS.hide(to: "#" <> @id)}>
@@ -349,7 +354,9 @@ defmodule ChatWeb.MainLive.Index do
       <h1 class="text-base font-bold text-grayscale"><%= @title %></h1>
       <p class="mt-3 text-sm text-black/50"><%= @description %></p>
       <div class="mt-5 flex items-center justify-between">
-        <button phx-click={hide_modal(@id)} class="w-full mr-1 h-12 border rounded-lg border-black/10">Cancel</button>
+        <button phx-click={hide_modal(@id)} class="w-full mr-1 h-12 border rounded-lg border-black/10">
+          Cancel
+        </button>
         <button class="confirmButton w-full ml-1 h-12 border-0 rounded-lg bg-grayscale text-white flex items-center justify-center">
           Confirm
         </button>

--- a/lib/chat_web/live/main_live/index.html.heex
+++ b/lib/chat_web/live/main_live/index.html.heex
@@ -1,55 +1,67 @@
 <div style="display: none;" id="session-link" phx-hook="LocalStateStore"></div>
 <div style="display: none;" id="time-link" phx-hook="LocalTime"></div>
 <%= unless connected?(@socket) do %>
-  <img class="vectorGroup bottomVectorGroup" src="/images/bottom_vector_group.svg"/>
-  <img class="vectorGroup topVectorGroup" src="/images/top_vector_group.svg"/>
+  <img class="vectorGroup bottomVectorGroup" src="/images/bottom_vector_group.svg" />
+  <img class="vectorGroup topVectorGroup" src="/images/top_vector_group.svg" />
 
   <div class="flex flex-col items-center justify-center w-screen h-screen">
-    <div class="container unauthenticated z-10" >
-      <img src="/images/logo.png"/>
+    <div class="container unauthenticated z-10">
+      <img src="/images/logo.png" />
     </div>
   </div>
 <% else %>
   <%= if @need_login do %>
-    <img class="vectorGroup bottomVectorGroup" src="/images/bottom_vector_group.svg"/>
-    <img class="vectorGroup topVectorGroup" src="/images/top_vector_group.svg"/>
+    <img class="vectorGroup bottomVectorGroup" src="/images/bottom_vector_group.svg" />
+    <img class="vectorGroup topVectorGroup" src="/images/top_vector_group.svg" />
     <div class="flex flex-col items-center justify-center w-screen h-screen">
-      <div class="container unauthenticated z-10" >
+      <div class="container unauthenticated z-10">
         <div class="flex justify-center">
-          <.icon id="logo" class="w-14 h-14 fill-white"/>
+          <.icon id="logo" class="w-14 h-14 fill-white" />
         </div>
         <div class="left-0 mt-10">
-          <h1 style="font-size: 28px; line-height: 34px;" class="font-inter font-bold text-white">Log In</h1>
-          <p class="mt-2.5 font-inter text-sm text-white/70">Please, enter your name. That’s how other users will see you</p>
+          <h1 style="font-size: 28px; line-height: 34px;" class="font-inter font-bold text-white">
+            Log In
+          </h1>
+          <p class="mt-2.5 font-inter text-sm text-white/70">
+            Please, enter your name. That’s how other users will see you
+          </p>
         </div>
         <div class="w-full mt-7">
-          <.form
-            let={f}
-            for={:login}
-            id="login-form"
-            class="t-login-form"
-            phx-submit="login">
-
-            <%= text_input f, :name, placeholder: "Your name", class: "w-full h-11 bg-transparent border border-white/50 rounded-lg text-white placeholder-white/50 focus:outline-none focus:ring-0 focus:border-white" %>
-            <%= error_tag f, :name %>
+          <.form :let={f} for={:login} id="login-form" class="t-login-form" phx-submit="login">
+            <%= text_input(f, :name,
+              placeholder: "Your name",
+              class:
+                "w-full h-11 bg-transparent border border-white/50 rounded-lg text-white placeholder-white/50 focus:outline-none focus:ring-0 focus:border-white"
+            ) %>
+            <%= error_tag(f, :name) %>
 
             <div class="mt-2.5">
-              <%= submit "Log In", phx_disable_with: "Saving...", class: "w-full h-11 focus:outline-none text-white px-4 rounded-lg", style: "background-color: rgb(36, 24, 36);"   %>
+              <%= submit("Log In",
+                phx_disable_with: "Saving...",
+                class: "w-full h-11 focus:outline-none text-white px-4 rounded-lg",
+                style: "background-color: rgb(36, 24, 36);"
+              ) %>
             </div>
           </.form>
         </div>
-        <div class="mt-7 flex flex-row items-center justify-between" >
-          <hr class="basis-[44%] border-1 border-white/10">
+        <div class="mt-7 flex flex-row items-center justify-between">
+          <hr class="basis-[44%] border-1 border-white/10" />
           <p class="text-white/50">or</p>
-          <hr class="basis-[44%] border-1 border-white/10">
+          <hr class="basis-[44%] border-1 border-white/10" />
         </div>
-        <button phx-click="login:request-key-ring" class="w-full h-11 mt-7 bg-transparent text-white py-2 px-4 border border-white/50 rounded-lg flex items-center justify-center">
+        <button
+          phx-click="login:request-key-ring"
+          class="w-full h-11 mt-7 bg-transparent text-white py-2 px-4 border border-white/50 rounded-lg flex items-center justify-center"
+        >
           <span>Login with QR code</span>
-          <.icon id="qrcode" class="w-4 h-4 ml-2 fill-white"/>
+          <.icon id="qrcode" class="w-4 h-4 ml-2 fill-white" />
         </button>
-        <button phx-click="login:import-own-key-ring" class="w-full h-11 mt-2.5 bg-transparent text-white py-2 px-4 border border-white/50 rounded-lg flex items-center justify-center">
+        <button
+          phx-click="login:import-own-key-ring"
+          class="w-full h-11 mt-2.5 bg-transparent text-white py-2 px-4 border border-white/50 rounded-lg flex items-center justify-center"
+        >
           <span>Import the recovery keys</span>
-          <.icon id="upload" class="w-4 h-4 ml-2 fill-white"/>
+          <.icon id="upload" class="w-4 h-4 ml-2 fill-white" />
         </button>
       </div>
     </div>
@@ -58,84 +70,170 @@
       <.modal id="logout-backup-popup" hide_event="logout-close" class="">
         <%= if @logout_step == :initial do %>
           <h1 class="text-base font-bold text-grayscale">Log Out & Back Up</h1>
-          <p class="mt-3 text-sm text-black/50">To get access again you will need the recovery keys:</p>
-          <button class="mt-5 w-full h-12 border-0 rounded-lg bg-grayscale flex items-center justify-center" phx-click="logout-go-middle">
+          <p class="mt-3 text-sm text-black/50">
+            To get access again you will need the recovery keys:
+          </p>
+          <button
+            class="mt-5 w-full h-12 border-0 rounded-lg bg-grayscale flex items-center justify-center"
+            phx-click="logout-go-middle"
+          >
             <div class="flex items-center justify-between">
               <span class="text-sm text-white t-download-key">Download the Keys</span>
-              <.icon id="upload" class="w-4 h-4 ml-2 fill-white"/>
+              <.icon id="upload" class="w-4 h-4 ml-2 fill-white" />
             </div>
           </button>
-          <button class="mt-3 w-full h-12 border rounded-lg border-black/10 t-logout-without-key" phx-click={hide_modal("logout-backup-popup") |>show_modal("logout-without-key-popup")}>Log Out without the Keys</button>
-          <button phx-click={hide_modal("logout-backup-popup")} class="mt-3 w-full h-12 border rounded-lg border-black/10 t-cancel-logout" >Cancel</button>
+          <button
+            class="mt-3 w-full h-12 border rounded-lg border-black/10 t-logout-without-key"
+            phx-click={
+              hide_modal("logout-backup-popup") |> show_modal("logout-without-key-popup")
+            }
+          >
+            Log Out without the Keys
+          </button>
+          <button
+            phx-click={hide_modal("logout-backup-popup")}
+            class="mt-3 w-full h-12 border rounded-lg border-black/10 t-cancel-logout"
+          >
+            Cancel
+          </button>
         <% end %>
         <%= if @logout_step == :middle do %>
           <h1 class="text-base font-bold text-grayscale">Set Up Password</h1>
-          <p class="mt-3 text-sm text-black/50">To store the backup copy of the key securely, enter the encryption password for the file</p>
+          <p class="mt-3 text-sm text-black/50">
+            To store the backup copy of the key securely, enter the encryption password for the file
+          </p>
           <div class="mt-5 w-full h-7 flex items-center justify-between border-0 rounded-lg bg-black/10">
-            <.icon id="alert" class="ml-1 w-4 h-4 fill-black/40"/>
-            <blockquote class="text-xs text-black/50 mr-3">This password in not stored and can NOT be recovered</blockquote>
+            <.icon id="alert" class="ml-1 w-4 h-4 fill-black/40" />
+            <blockquote class="text-xs text-black/50 mr-3">
+              This password in not stored and can NOT be recovered
+            </blockquote>
           </div>
           <.form
-            let={f}
+            :let={f}
             for={@changeset}
             id="logout-form"
             phx-change="logout-check-password"
             phx-submit="logout-download-with-password"
             as={:logout}
-            class="mt-3 w-full">
+            class="mt-3 w-full"
+          >
             <div class="w-ull relative">
               <%= if @is_password_visible do %>
-                <%= text_input f, :password, type: "text", placeholder: "Enter Password", phx_debounce: 700, class: "w-full h-12 placeholder-black/50 border rounded-lg border-black/10 focus:outline-none focus:ring-0 focus:border-black/50" %>
-                <a phx-click="logout:toggle-password-visibility"><.icon id="visibility" class="w-4 h-4 absolute top-4 right-3 ml-2"/></a>
+                <%= text_input(f, :password,
+                  type: "text",
+                  placeholder: "Enter Password",
+                  phx_debounce: 700,
+                  class:
+                    "w-full h-12 placeholder-black/50 border rounded-lg border-black/10 focus:outline-none focus:ring-0 focus:border-black/50"
+                ) %>
+                <a phx-click="logout:toggle-password-visibility">
+                  <.icon id="visibility" class="w-4 h-4 absolute top-4 right-3 ml-2" />
+                </a>
               <% else %>
-                <%= text_input f, :password, type: "password", placeholder: "Enter Password", phx_debounce: 700, class: "w-full h-12 placeholder-black/50 border rounded-lg border-black/10 focus:outline-none focus:ring-0 focus:border-black/50" %>
-                <a phx-click="logout:toggle-password-visibility"><.icon id="visibilityOff" class="w-4 h-4 absolute top-4 right-3 ml-2"/></a>
+                <%= text_input(f, :password,
+                  type: "password",
+                  placeholder: "Enter Password",
+                  phx_debounce: 700,
+                  class:
+                    "w-full h-12 placeholder-black/50 border rounded-lg border-black/10 focus:outline-none focus:ring-0 focus:border-black/50"
+                ) %>
+                <a phx-click="logout:toggle-password-visibility">
+                  <.icon id="visibilityOff" class="w-4 h-4 absolute top-4 right-3 ml-2" />
+                </a>
               <% end %>
             </div>
             <!--<%= error_tag f, :password %> -->
             <div class="mt-3 w-ull relative">
               <%= if @is_password_confirmation_visible do %>
-                <%= text_input f, :password_confirmation, type: "text", placeholder: "Repeat Password", phx_debounce: 700, class: "w-full h-12 placeholder-black/50 border rounded-lg border-black/10 focus:outline-none focus:ring-0 focus:border-black/50" %>
-                <a phx-click="logout:toggle-password-confirmation-visibility"><.icon id="visibility" class="w-4 h-4 absolute top-4 right-3 ml-2"/></a>
+                <%= text_input(f, :password_confirmation,
+                  type: "text",
+                  placeholder: "Repeat Password",
+                  phx_debounce: 700,
+                  class:
+                    "w-full h-12 placeholder-black/50 border rounded-lg border-black/10 focus:outline-none focus:ring-0 focus:border-black/50"
+                ) %>
+                <a phx-click="logout:toggle-password-confirmation-visibility">
+                  <.icon id="visibility" class="w-4 h-4 absolute top-4 right-3 ml-2" />
+                </a>
               <% else %>
-                <%= text_input f, :password_confirmation, type: "password", placeholder: "Repeat Password", phx_debounce: 700, class: "w-full h-12 placeholder-black/50 border rounded-lg border-black/10 focus:outline-none focus:ring-0 focus:border-black/50" %>
-                <a phx-click="logout:toggle-password-confirmation-visibility"><.icon id="visibilityOff" class="w-4 h-4 absolute top-4 right-3 ml-2"/></a>
+                <%= text_input(f, :password_confirmation,
+                  type: "password",
+                  placeholder: "Repeat Password",
+                  phx_debounce: 700,
+                  class:
+                    "w-full h-12 placeholder-black/50 border rounded-lg border-black/10 focus:outline-none focus:ring-0 focus:border-black/50"
+                ) %>
+                <a phx-click="logout:toggle-password-confirmation-visibility">
+                  <.icon id="visibilityOff" class="w-4 h-4 absolute top-4 right-3 ml-2" />
+                </a>
               <% end %>
             </div>
             <!-- <%= error_tag f, :password_confirmation %> -->
             <p class="mt-3 text-sm text-black/50">At least 12 symbols</p>
-            <%= submit "Download", phx_disable_with: "Downloading...", class: "mt-5 w-full h-12 border-0 rounded-lg bg-grayscale text-white disabled:opacity-50", disabled: !@changeset.valid? %>
+            <%= submit("Download",
+              phx_disable_with: "Downloading...",
+              class:
+                "mt-5 w-full h-12 border-0 rounded-lg bg-grayscale text-white disabled:opacity-50",
+              disabled: !@changeset.valid?
+            ) %>
           </.form>
-          <button class="mt-3 w-full h-12 border rounded-lg border-black/10" phx-click="logout-download-insecure">
+          <button
+            class="mt-3 w-full h-12 border rounded-lg border-black/10"
+            phx-click="logout-download-insecure"
+          >
             Download without password <span style="color: red">insecure!</span>
           </button>
         <% end %>
         <%= if @logout_step == :final do %>
           <h1 class="text-base font-bold text-grayscale">Success</h1>
-          <p class="mt-3 text-sm text-black/50">If you downloaded the the recovery key, you can log out now, it will erase all the browser data about BuckitUp.</p>
-          <button class="mt-3 w-full h-12 border-0 rounded-lg bg-grayscale text-white t-exit" phx-click="logout-wipe">Exit</button>
-          <button phx-click={hide_modal("logout-backup-popup")} class="mt-3 w-full h-12 border rounded-lg border-black/10">Cancel</button>
+          <p class="mt-3 text-sm text-black/50">
+            If you downloaded the the recovery key, you can log out now, it will erase all the browser data about BuckitUp.
+          </p>
+          <button
+            class="mt-3 w-full h-12 border-0 rounded-lg bg-grayscale text-white t-exit"
+            phx-click="logout-wipe"
+          >
+            Exit
+          </button>
+          <button
+            phx-click={hide_modal("logout-backup-popup")}
+            class="mt-3 w-full h-12 border rounded-lg border-black/10"
+          >
+            Cancel
+          </button>
         <% end %>
       </.modal>
       <.modal id="delete-message-popup" class="t-delete-message-popup">
         <h1 class="text-base font-bold text-grayscale">Delete Message</h1>
         <p class="mt-3 text-sm text-black/50">Are you sure you want to do this?</p>
         <div class="mt-5 flex items-center justify-between">
-          <button phx-click={hide_modal("delete-message-popup")} class="w-full mr-1 h-12 border rounded-lg border-black/10 t-delete-cancel">Cancel</button>
+          <button
+            phx-click={hide_modal("delete-message-popup")}
+            class="w-full mr-1 h-12 border rounded-lg border-black/10 t-delete-cancel"
+          >
+            Cancel
+          </button>
           <button class="deleteMessageButton w-full ml-1 h-12 border-0 rounded-lg bg-red-500 flex items-center justify-center t-delete-message-btn">
             <span class="text-white mr-1">Delete</span>
-            <.icon id="delete" class="w-4 h-4 fill-white"/>
+            <.icon id="delete" class="w-4 h-4 fill-white" />
           </button>
         </div>
       </.modal>
       <.modal id="delete-messages-popup" class="">
         <h1 class="text-base font-bold text-grayscale">Delete Messages</h1>
-        <p class="mt-3 text-sm text-black/50">You can only delete your own messages. Are you sure you want to delete this message?</p>
+        <p class="mt-3 text-sm text-black/50">
+          You can only delete your own messages. Are you sure you want to delete this message?
+        </p>
         <div class="mt-5 flex items-center justify-between">
-          <button phx-click={hide_modal("delete-messages-popup")} class="w-full mr-1 h-12 border rounded-lg border-black/10 t-cancel-delete-msg-popup-btn">Cancel</button>
+          <button
+            phx-click={hide_modal("delete-messages-popup")}
+            class="w-full mr-1 h-12 border rounded-lg border-black/10 t-cancel-delete-msg-popup-btn"
+          >
+            Cancel
+          </button>
           <button class="deleteMessageButton w-full ml-1 h-12 border-0 rounded-lg bg-red-500 flex items-center justify-center t-delete-message-popup-btn">
             <span class="text-white mr-1">Delete</span>
-            <.icon id="delete" class="w-4 h-4 fill-white"/>
+            <.icon id="delete" class="w-4 h-4 fill-white" />
           </button>
         </div>
       </.modal>
@@ -143,7 +241,12 @@
         <h1 class="text-base font-bold text-grayscale">Log Out without the Key</h1>
         <p class="mt-3 text-sm text-black/50">Are you sure you want to do this?</p>
         <div class="mt-5 flex items-center justify-between">
-          <button phx-click={hide_modal("logout-without-key-popup")} class="w-full mr-1 h-12 border rounded-lg border-black/10">Cancel</button>
+          <button
+            phx-click={hide_modal("logout-without-key-popup")}
+            class="w-full mr-1 h-12 border rounded-lg border-black/10"
+          >
+            Cancel
+          </button>
           <button class="w-full ml-1 h-12 border-0 rounded-lg bg-grayscale  flex items-center justify-center">
             <span phx-click="logout-wipe" class="text-white mr-1 t-logout-btn">Logout</span>
           </button>
@@ -151,150 +254,291 @@
       </.modal>
       <div class="w-screen h-screen flex flex-nowrap flex-row">
         <div id="navbarTop" class="navbarTop px-4">
-          <div phx-click={JS.push("switch-lobby-mode") |> open_content()} phx-value-lobby-mode="feeds" class="sidebarIcon">
-            <.icon id="logo" class="w-6 h-6"/>
+          <div
+            phx-click={JS.push("switch-lobby-mode") |> open_content()}
+            phx-value-lobby-mode="feeds"
+            class="sidebarIcon"
+          >
+            <.icon id="logo" class="w-6 h-6" />
           </div>
-           <Layout.DbStatus.mobile status={@db_status} />
-          <button class="flex justify-between min-w-max" phx-click={JS.push("logout-open") |> show_modal("logout-backup-popup")} class="sidebarIcon mb-1">
-            <.icon id="logout" class="w-4 h-4 hover:fill-purple"/>
+          <Layout.DbStatus.mobile status={@db_status} />
+          <button
+            class="flex justify-between min-w-max"
+            phx-click={JS.push("logout-open") |> show_modal("logout-backup-popup")}
+            class="sidebarIcon mb-1"
+          >
+            <.icon id="logout" class="w-4 h-4 hover:fill-purple" />
             <span class="text-xs">Log out & Back Up</span>
           </button>
         </div>
         <div id="navbarBottom" class="navbarBottom px-20">
           <button phx-click="switch-lobby-mode" phx-value-lobby-mode="rooms" class="sidebarIcon">
-            <.icon id="sidebarRooms" class={classes("w-6 h-6 hover:fill-purple", %{"fill-purple" => @lobby_mode == :rooms, "fill-grayscale" => @lobby_mode != :rooms})}/>
+            <.icon
+              id="sidebarRooms"
+              class={
+                classes("w-6 h-6 hover:fill-purple", %{
+                  "fill-purple" => @lobby_mode == :rooms,
+                  "fill-grayscale" => @lobby_mode != :rooms
+                })
+              }
+            />
             <span class="text-xs">Rooms</span>
           </button>
           <button phx-click="switch-lobby-mode" phx-value-lobby-mode="chats" class="sidebarIcon">
-            <.icon id="sidebarChats" class={classes("w-6 h-6 hover:fill-purple", %{"fill-purple" => @lobby_mode == :chats, "fill-grayscale" => @lobby_mode != :chats})}/>
+            <.icon
+              id="sidebarChats"
+              class={
+                classes("w-6 h-6 hover:fill-purple", %{
+                  "fill-purple" => @lobby_mode == :chats,
+                  "fill-grayscale" => @lobby_mode != :chats
+                })
+              }
+            />
             <span class="text-xs">Chats</span>
           </button>
           <%= if @is_admin do %>
-          <button phx-click="switch-lobby-mode" phx-value-lobby-mode="admin" class="sidebarIcon ">
-            <.icon id="admin" class={classes("w-5 h-5 hover:fill-purple", %{"fill-purple" => @lobby_mode == :admin, "fill-grayscale" => @lobby_mode != :admin})}/>
-            <span class="text-xs">Admin</span>
-          </button>
+            <button
+              phx-click="switch-lobby-mode"
+              phx-value-lobby-mode="admin"
+              class="sidebarIcon "
+            >
+              <.icon
+                id="admin"
+                class={
+                  classes("w-5 h-5 hover:fill-purple", %{
+                    "fill-purple" => @lobby_mode == :admin,
+                    "fill-grayscale" => @lobby_mode != :admin
+                  })
+                }
+              />
+              <span class="text-xs">Admin</span>
+            </button>
           <% end %>
         </div>
         <div class="navbar">
           <div class="sm:flex flex-col items-center">
-            <div phx-click={JS.push("switch-lobby-mode")} phx-value-lobby-mode="feeds" class="sidebarIcon cursor-pointer mt-3 t-feeds">
-              <.icon id="logo" class="w-9 h-9"/>
+            <div
+              phx-click={JS.push("switch-lobby-mode")}
+              phx-value-lobby-mode="feeds"
+              class="sidebarIcon cursor-pointer mt-3 t-feeds"
+            >
+              <.icon id="logo" class="w-9 h-9" />
             </div>
-            <button phx-click="switch-lobby-mode" phx-value-lobby-mode="rooms" class="sidebarIcon mt-9 t-rooms">
-              <.icon id="sidebarRooms" class={classes("w-6 h-6 hover:fill-purple", %{"fill-purple" => @lobby_mode == :rooms, "fill-grayscale" => @lobby_mode != :rooms})}/>
+            <button
+              phx-click="switch-lobby-mode"
+              phx-value-lobby-mode="rooms"
+              class="sidebarIcon mt-9 t-rooms"
+            >
+              <.icon
+                id="sidebarRooms"
+                class={
+                  classes("w-6 h-6 hover:fill-purple", %{
+                    "fill-purple" => @lobby_mode == :rooms,
+                    "fill-grayscale" => @lobby_mode != :rooms
+                  })
+                }
+              />
               <span class="text-xs">Rooms</span>
             </button>
-            <button phx-click="switch-lobby-mode" phx-value-lobby-mode="chats" class="sidebarIcon mt-5 t-chats">
-              <.icon id="sidebarChats" class={classes("w-6 h-6 hover:fill-purple", %{"fill-purple" => @lobby_mode == :chats, "fill-grayscale" => @lobby_mode != :chats})}/>
+            <button
+              phx-click="switch-lobby-mode"
+              phx-value-lobby-mode="chats"
+              class="sidebarIcon mt-5 t-chats"
+            >
+              <.icon
+                id="sidebarChats"
+                class={
+                  classes("w-6 h-6 hover:fill-purple", %{
+                    "fill-purple" => @lobby_mode == :chats,
+                    "fill-grayscale" => @lobby_mode != :chats
+                  })
+                }
+              />
               <span class="text-xs">Chats</span>
             </button>
             <%= if @is_admin do %>
-            <button phx-click="switch-lobby-mode" phx-value-lobby-mode="admin" class="sidebarIcon mt-5">
-              <.icon id="admin" class={classes("w-5 h-5 hover:fill-purple", %{"fill-purple" => @lobby_mode == :admin, "fill-grayscale" => @lobby_mode != :admin})}/>
-              <span class="text-xs">Admin</span>
-            </button>
+              <button
+                phx-click="switch-lobby-mode"
+                phx-value-lobby-mode="admin"
+                class="sidebarIcon mt-5"
+              >
+                <.icon
+                  id="admin"
+                  class={
+                    classes("w-5 h-5 hover:fill-purple", %{
+                      "fill-purple" => @lobby_mode == :admin,
+                      "fill-grayscale" => @lobby_mode != :admin
+                    })
+                  }
+                />
+                <span class="text-xs">Admin</span>
+              </button>
             <% end %>
           </div>
           <div class="flex flex-col items-center">
             <div class="row mt-10">
               <Layout.DbStatus.desktop status={@db_status} />
-              <button phx-click={JS.push("logout-open") |> show_modal("logout-backup-popup")} class="sidebarIcon mb-1">
-                <.icon id="logout" class="w-6 h-6 hover:fill-purple"/>
+              <button
+                phx-click={JS.push("logout-open") |> show_modal("logout-backup-popup")}
+                class="sidebarIcon mb-1"
+              >
+                <.icon id="logout" class="w-6 h-6 hover:fill-purple" />
                 <span class="text-xs t-logout">Log out & Back Up</span>
               </button>
             </div>
           </div>
         </div>
         <%= if @lobby_mode == :chats do %>
-          <div id="chatRoomBar" class='chatRoomBar'>
-            <div class='px-7 mt-3 flex items-center justify-between'>
+          <div id="chatRoomBar" class="chatRoomBar">
+            <div class="px-7 mt-3 flex items-center justify-between">
               <h5 class="text-grayscale" style="font-size: 22px;">Chats</h5>
             </div>
             <div class="mt-10 w-full">
-              <ul><%= for user <- @users do %>
-                <li phx-click="dialog/switch" phx-value-user-id={user.hash} class={classes("hidden sm:flex w-full cursor-pointer h-9 flex items-center hover:bg-stone250", %{"from-green-400 to-blue-500" => user == @peer})}>
-                  <a><div class="flex flex-row px-7">
-                    <%= if @my_id == user.hash do %>
-                      <div class="ml-1 text-sm t-my-notes"> My notes </div>
-                    <% else %>
-                      <tt class="text-sm tracking-tighter text-grayscale600">[<%= short_hash(user.hash) %>]</tt>
-                      <div class="ml-1 text-sm"><%= user.name %></div>
-                    <% end %>
-                  </div></a>
-                </li>
-                <li phx-click={JS.push("dialog/switch") |> open_content()} phx-value-user-id={user.hash} class={classes("sm:hidden w-full cursor-pointer h-9 flex items-center hover:bg-stone250", %{"bg-stone250" => user == @peer})}>
-                  <a><div class="flex flex-row px-7">
-                    <tt class="text-sm tracking-tighter text-grayscale600">[<%= short_hash(user.hash) %>]</tt>
-                    <div class="ml-1 text-sm"><%= user == Chat.Card.from_identity(@me) && "My notes" || user.name %></div>
-                  </div></a>
-                </li>
-              <% end %></ul>
+              <ul>
+                <%= for user <- @users do %>
+                  <li
+                    phx-click="dialog/switch"
+                    phx-value-user-id={user.hash}
+                    class={
+                      classes(
+                        "hidden sm:flex w-full cursor-pointer h-9 flex items-center hover:bg-stone250",
+                        %{"from-green-400 to-blue-500" => user == @peer}
+                      )
+                    }
+                  >
+                    <a>
+                      <div class="flex flex-row px-7">
+                        <%= if @my_id == user.hash do %>
+                          <div class="ml-1 text-sm t-my-notes">My notes</div>
+                        <% else %>
+                          <tt class="text-sm tracking-tighter text-grayscale600">
+                            [<%= short_hash(user.hash) %>]
+                          </tt>
+                          <div class="ml-1 text-sm"><%= user.name %></div>
+                        <% end %>
+                      </div>
+                    </a>
+                  </li>
+                  <li
+                    phx-click={JS.push("dialog/switch") |> open_content()}
+                    phx-value-user-id={user.hash}
+                    class={
+                      classes(
+                        "sm:hidden w-full cursor-pointer h-9 flex items-center hover:bg-stone250",
+                        %{"bg-stone250" => user == @peer}
+                      )
+                    }
+                  >
+                    <a>
+                      <div class="flex flex-row px-7">
+                        <tt class="text-sm tracking-tighter text-grayscale600">
+                          [<%= short_hash(user.hash) %>]
+                        </tt>
+                        <div class="ml-1 text-sm">
+                          <%= (user == Chat.Card.from_identity(@me) && "My notes") || user.name %>
+                        </div>
+                      </div>
+                    </a>
+                  </li>
+                <% end %>
+              </ul>
             </div>
           </div>
-          <div id="contentContainer" class="from-green-400 to-blue-500 hidden sm:flex flex flex-col contentContainer">
+          <div
+            id="contentContainer"
+            class="from-green-400 to-blue-500 hidden sm:flex flex flex-col contentContainer"
+          >
             <%= unless @dialog do %>
             <% else %>
               <Layout.ImageGallery.render mode="dialog" gallery={@image_gallery} />
-            <div id="chatContent"
-                  phx-hook="Chat"
-                  class="basis-[93%] pb-1 md:pb-0 overflow-y-auto flex flex-col justify-between relative a-content-block t-chat-content" id={"chat-#{@peer.hash}"}
-                  data-page={@page}
-                  data-has-more-messages={"#{@has_more_messages}"}>
-                    <div id="chatHeader"
-                      phx-click={JS.dispatch("phx:scroll-to-bottom")}
-                      class="w-full px-8 border-b border-white/10 backdrop-blur-md bg-white/10 z-10 flex flex-row items-center justify-start sticky top-0 right-0 t-chat-header"
-                      style="min-height: 56px;">
-                      <button phx-click={JS.push("dialog/close") |> close_content()} class="sm:hidden pr-3">
-                        <.icon id="arrowBack" class="w-6 h-6 fill-white"/>
-                      </button>
-                      <%= if @my_id == @peer.hash do %>
-                        <h1 class="ml-1 text-base font-bolt text-white" >
-                           My private notes
-                        </h1>
-                        <div class="text-base text-white/60 ml-2">[<%= short_hash(@peer.hash) %>]</div>
-                        <h1 class="ml-1 text-base font-bolt text-white t-peer-name" ><%= @peer.name %></h1>
-                      <% else %>
-                        <div class="text-base text-white/60">[<%= short_hash(@peer.hash) %>]</div>
-                        <h1 class="ml-1 text-base font-bolt text-white t-peer-name" ><%= @peer.name %></h1>
-                        <button>
-                          <.icon id="edit" class="w-4 h-4 ml-1 flex fill-white/50"/>
-                        </button>
-                      <% end %>
+              <div
+                id="chatContent"
+                phx-hook="Chat"
+                class="basis-[93%] pb-1 md:pb-0 overflow-y-auto flex flex-col justify-between relative a-content-block t-chat-content"
+                id={"chat-#{@peer.hash}"}
+                data-page={@page}
+                data-has-more-messages={"#{@has_more_messages}"}
+              >
+                <div
+                  id="chatHeader"
+                  phx-click={JS.dispatch("phx:scroll-to-bottom")}
+                  class="w-full px-8 border-b border-white/10 backdrop-blur-md bg-white/10 z-10 flex flex-row items-center justify-start sticky top-0 right-0 t-chat-header"
+                  style="min-height: 56px;"
+                >
+                  <button
+                    phx-click={JS.push("dialog/close") |> close_content()}
+                    class="sm:hidden pr-3"
+                  >
+                    <.icon id="arrowBack" class="w-6 h-6 fill-white" />
+                  </button>
+                  <%= if @my_id == @peer.hash do %>
+                    <h1 class="ml-1 text-base font-bolt text-white">
+                      My private notes
+                    </h1>
+                    <div class="text-base text-white/60 ml-2">
+                      [<%= short_hash(@peer.hash) %>]
                     </div>
-                  <div>
-                    <div id="chat-messages" phx-update={@message_update_mode}>
-                      <%= for msg <- @messages do %>
-                        <Layout.Message.message_block chat_type={:dialog} me={@me} msg={msg} peer={@peer} timezone={@timezone} />
-                      <% end %>
-                    </div>
-                    <div class="px-2 sm:px-8" phx-update="replace" id="dialog-uploads">
-                      <%= for %{valid?: true} = entry <- @uploads.image.entries do %>
-                        <div id={"upload#{entry.uuid}"} class="m-1 flex justify-end">
-                          <div class="flex-col max-w-xxs sm:max-w-md min-w-[180px]">
-                            <%= live_img_preview entry, class: "blur-sm animate-pulse" %>
-
-                            <div class="w-full bg-gray-200 h-2 dark:bg-gray-700">
-                              <div class="bg-gray-600 h-2 dark:bg-gray-300" style={"width: #{entry.progress}%"}></div>
-                            </div>
-                          </div>
-                        </div>
-                      <% end %>
-                      <%= for %{valid?: true} = entry <- @uploads.dialog_file.entries do %>
-                        <div id={"upload#{entry.uuid}"} class="m-1 flex justify-end">
-                          <div class="bg-purple50 max-w-xxs sm:max-w-md min-w-[180px] rounded-lg flex items-center justify-between">
-                            <.icon id="document" class="w-14 h-14 flex fill-black/50 animate-pulse"/>
-                            <div class="w-36 flex flex-col pr-3">
-                              <span class="truncate text-xs"><%= entry.client_name %></span>
-                              <div class="text-xs text-black/50"><%= entry.progress %>% uploaded</div>
-                            </div>
-                          </div>
-                        </div>
-                      <% end %>
-                    </div>
+                    <h1 class="ml-1 text-base font-bolt text-white t-peer-name">
+                      <%= @peer.name %>
+                    </h1>
+                  <% else %>
+                    <div class="text-base text-white/60">[<%= short_hash(@peer.hash) %>]</div>
+                    <h1 class="ml-1 text-base font-bolt text-white t-peer-name">
+                      <%= @peer.name %>
+                    </h1>
+                    <button>
+                      <.icon id="edit" class="w-4 h-4 ml-1 flex fill-white/50" />
+                    </button>
+                  <% end %>
+                </div>
+                <div>
+                  <div id="chat-messages" phx-update={@message_update_mode}>
+                    <%= for msg <- @messages do %>
+                      <Layout.Message.message_block
+                        chat_type={:dialog}
+                        me={@me}
+                        msg={msg}
+                        peer={@peer}
+                        timezone={@timezone}
+                      />
+                    <% end %>
                   </div>
+                  <div class="px-2 sm:px-8" phx-update="replace" id="dialog-uploads">
+                    <%= for %{valid?: true} = entry <- @uploads.image.entries do %>
+                      <div id={"upload#{entry.uuid}"} class="m-1 flex justify-end">
+                        <div class="flex-col max-w-xxs sm:max-w-md min-w-[180px]">
+                          <%= live_img_preview(entry, class: "blur-sm animate-pulse") %>
+
+                          <div class="w-full bg-gray-200 h-2 dark:bg-gray-700">
+                            <div
+                              class="bg-gray-600 h-2 dark:bg-gray-300"
+                              style={"width: #{entry.progress}%"}
+                            >
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    <% end %>
+                    <%= for %{valid?: true} = entry <- @uploads.dialog_file.entries do %>
+                      <div id={"upload#{entry.uuid}"} class="m-1 flex justify-end">
+                        <div class="bg-purple50 max-w-xxs sm:max-w-md min-w-[180px] rounded-lg flex items-center justify-between">
+                          <.icon id="document" class="w-14 h-14 flex fill-black/50 animate-pulse" />
+                          <div class="w-36 flex flex-col pr-3">
+                            <span class="truncate text-xs"><%= entry.client_name %></span>
+                            <div class="text-xs text-black/50">
+                              <%= entry.progress %>% uploaded
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    <% end %>
+                  </div>
+                </div>
               </div>
-              <div id="dialogInput" class="basis-[7%] w-full py-1.5 px-8 border border-white bg-white flex items-center fixed md:sticky bottom-0">
+              <div
+                id="dialogInput"
+                class="basis-[7%] w-full py-1.5 px-8 border border-white bg-white flex items-center fixed md:sticky bottom-0"
+              >
                 <%= if @dialog_mode == :plain do %>
                   <.form
                     for={:dialog_file}
@@ -303,17 +547,17 @@
                     phx-change="dialog/import-files"
                     phx-drop-target={@uploads.dialog_file.ref}
                   >
-                    <%= live_file_input @uploads.dialog_file, style: "display: none"  %>
+                    <%= live_file_input(@uploads.dialog_file, style: "display: none") %>
                   </.form>
                   <button
                     id="attachFileBtn"
                     class="relative"
                     phx-click={JS.dispatch("click", to: "#dialog-file-form input[type=file]")}
                   >
-                    <.icon id="attach" class="w-7 h-7 flex fill-white"/>
+                    <.icon id="attach" class="w-7 h-7 flex fill-white" />
                   </button>
                   <.form
-                    let={di}
+                    :let={di}
                     for={:dialog}
                     id="dialog-form"
                     class="basis-[99%] flex items-center justify-between"
@@ -327,16 +571,22 @@
                       if (event.key == 'Enter' && event.shiftKey) {
                         document.getElementById('dialog-form-submit-button').click()
                       }
-                    ">
-                    <%= textarea di, :text,
+                    "
+                  >
+                    <%= textarea(di, :text,
                       placeholder: "Enter message",
-                      class: "w-full h-10 resize-none border-0 overflow-y-auto text-black placeholder-black/50 focus:ring-0 t-chat-input",
+                      class:
+                        "w-full h-10 resize-none border-0 overflow-y-auto text-black placeholder-black/50 focus:ring-0 t-chat-input",
                       id: "dialog-input",
                       spellcheck: "false",
                       autocomplete: "off"
-                    %>
-                    <button id="dialog-form-submit-button" class="t-chat-send-message-btn" type="submit">
-                      <.icon id="send" class="w-7 h-7 flex fill-purple"/>
+                    ) %>
+                    <button
+                      id="dialog-form-submit-button"
+                      class="t-chat-send-message-btn"
+                      type="submit"
+                    >
+                      <.icon id="send" class="w-7 h-7 flex fill-purple" />
                     </button>
                   </.form>
                 <% end %>
@@ -345,54 +595,82 @@
                     <div class="flex items-center justify-between pb-2 mt-2">
                       <div class="w-[70vw]">
                         <h1 class="text-purple t-edit">Editing</h1>
-                        <span class="truncate block text-xs text-black/50"><%= @edit_content %></span>
+                        <span class="truncate block text-xs text-black/50">
+                          <%= @edit_content %>
+                        </span>
                       </div>
                       <button type="button" class="t-cancel-edit" phx-click="dialog/cancel-edit">
-                        <.icon id="close" class="w-7 h-7 flex fill-black/50"/>
+                        <.icon id="close" class="w-7 h-7 flex fill-black/50" />
                       </button>
                     </div>
                     <.form
-                      let={dei}
+                      :let={dei}
                       for={:dialog_edit}
                       id="dialog-edit-form"
                       class="flex items-center justify-start "
                       phx-change={JS.dispatch("chat:set-input-size", to: "#dialog-edit-input")}
-                      phx-submit={JS.push("dialog/edited-message") |> JS.dispatch("chat:clear-value", to: "#dialog-edit-input") |> JS.dispatch("chat:set-input-size", to: "#dialog-edit-input")}
+                      phx-submit={
+                        JS.push("dialog/edited-message")
+                        |> JS.dispatch("chat:clear-value", to: "#dialog-edit-input")
+                        |> JS.dispatch("chat:set-input-size", to: "#dialog-edit-input")
+                      }
                       onkeydown="
                       if (event.key == 'Enter' && event.shiftKey) {
                         document.getElementById('dialog-edit-form-submit-button').click()
                       }
-                      ">
-                      <%= textarea dei, :text, class: "w-full px-0 resize-none outline-none border-0 overflow-scroll text-black placeholder-black/50 focus:ring-0 t-chat-edit-input",
-                            id: "dialog-edit-input",
-                            spellcheck: "false",
-                            autocomplete: "off",
-                            value: @edit_content
-                      %>
-                      <button id="dialog-edit-form-submit-button" class="t-chat-edit-send-btn" type="submit">
-                        <.icon id="send" class="w-7 h-7 flex fill-purple"/>
+                      "
+                    >
+                      <%= textarea(dei, :text,
+                        class:
+                          "w-full px-0 resize-none outline-none border-0 overflow-scroll text-black placeholder-black/50 focus:ring-0 t-chat-edit-input",
+                        id: "dialog-edit-input",
+                        spellcheck: "false",
+                        autocomplete: "off",
+                        value: @edit_content
+                      ) %>
+                      <button
+                        id="dialog-edit-form-submit-button"
+                        class="t-chat-edit-send-btn"
+                        type="submit"
+                      >
+                        <.icon id="send" class="w-7 h-7 flex fill-purple" />
                       </button>
                     </.form>
                   </div>
                 <% end %>
                 <%= if @dialog_mode == :select do %>
                   <div class="w-full h-11 bg-white flex justify-between items-center">
-                    <button id="delete-btn" class="cursor-pointer inline-flex items-center disabled:pointer-events-none t-delete-chat-msg-btn"
-                      phx-click={show_modal("delete-messages-popup")
-                                 |> JS.set_attribute({"phx-click", hide_modal("delete-messages-popup")
-                                                                   |> JS.push("dialog/delete-messages")
-                                                                   |> stringify_commands()},
-                                                                   to: "#delete-messages-popup .deleteMessageButton")
-                                 |> JS.dispatch("chat:messages-to-delete", to: "#delete-messages-popup") }
+                    <button
+                      id="delete-btn"
+                      class="cursor-pointer inline-flex items-center disabled:pointer-events-none t-delete-chat-msg-btn"
+                      phx-click={
+                        show_modal("delete-messages-popup")
+                        |> JS.set_attribute(
+                          {"phx-click",
+                           hide_modal("delete-messages-popup")
+                           |> JS.push("dialog/delete-messages")
+                           |> stringify_commands()},
+                          to: "#delete-messages-popup .deleteMessageButton"
+                        )
+                        |> JS.dispatch("chat:messages-to-delete", to: "#delete-messages-popup")
+                      }
                     >
-                      <.icon id="delete" class="w-4 h-4 flex fill-black x-icon"/>
+                      <.icon id="delete" class="w-4 h-4 flex fill-black x-icon" />
                       <span id="delete-span">Delete</span>
-                  </button>
+                    </button>
 
-                    <button id="download-btn" class="cursor-pointer inline-flex items-center t-download-chat-msg-btn"
-                    phx-click={JS.dispatch("chat:download-messages", to: "#chatContent", detail: %{chatType: "dialog"})}>
+                    <button
+                      id="download-btn"
+                      class="cursor-pointer inline-flex items-center t-download-chat-msg-btn"
+                      phx-click={
+                        JS.dispatch("chat:download-messages",
+                          to: "#chatContent",
+                          detail: %{chatType: "dialog"}
+                        )
+                      }
+                    >
                       <span class="text-purple">Download</span>
-                      <.icon id="download" class="ml-1 w-4 h-4 flex  stroke-purple "/>
+                      <.icon id="download" class="ml-1 w-4 h-4 flex  stroke-purple " />
                     </button>
                   </div>
                 <% end %>
@@ -402,72 +680,126 @@
         <% end %>
         <%= if @lobby_mode == :rooms do %>
           <.flash_notification id="inviteSentNotification" />
-          <div id="chatRoomBar" class='chatRoomBar'>
+          <div id="chatRoomBar" class="chatRoomBar">
             <.modal id="create-room-popup" class="">
               <h1 class="text-base font-bold text-grayscale">Create Room</h1>
               <.form
-                let={f}
+                :let={f}
                 for={:new_room}
                 id="room-create-form"
                 autocomplete="off"
                 phx-submit={hide_modal("create-room-popup") |> JS.push("room/create")}
               >
-                <%= text_input f, :name, placeholder: "Name your Room", class: "w-full h-11 mt-4 border border-gray-300 rounded-lg focus:outline-none focus:ring-0" %>
+                <%= text_input(f, :name,
+                  placeholder: "Name your Room",
+                  class:
+                    "w-full h-11 mt-4 border border-gray-300 rounded-lg focus:outline-none focus:ring-0"
+                ) %>
 
                 <p class="mt-3 text-black/50 text-sm">Room Type</p>
                 <div class="mt-3 flex flex-col">
                   <a class="inline t-open-room">
                     <input
-                      class="cursor-pointer text-orange-500" type="radio" id="typeChoice1" name="new_room[type]" value="public" checked
-                      phx-click={JS.dispatch("room:switch-type",
-                                        to: "#typeChoice1",
-                                        detail: %{
-                                          description: "Public room is visible for everyone. Anyone can join.",
-                                          id: "roomTypeDescription"
-                                        }
-                                      )}
-                    >
-                    <label class="cursor-pointer ml-1 text-black/50 text-sm" for="typeChoice1">Open</label>
+                      class="cursor-pointer text-orange-500"
+                      type="radio"
+                      id="typeChoice1"
+                      name="new_room[type]"
+                      value="public"
+                      checked
+                      phx-click={
+                        JS.dispatch("room:switch-type",
+                          to: "#typeChoice1",
+                          detail: %{
+                            description: "Public room is visible for everyone. Anyone can join.",
+                            id: "roomTypeDescription"
+                          }
+                        )
+                      }
+                    />
+                    <label class="cursor-pointer ml-1 text-black/50 text-sm" for="typeChoice1">
+                      Open
+                    </label>
                   </a>
                   <a class="inline">
-                    <input class="cursor-pointer text-orange-500 t-private-room" type="radio" id="typeChoice2" name="new_room[type]" value="request"
-                           phx-click={JS.dispatch("room:switch-type",
-                                        to: "#typeChoice2",
-                                        detail: %{
-                                          description: "Private Room is visible for everyone. Anyone can send request and join if approved by a room member",
-                                          id: "roomTypeDescription"
-                                        }
-                                      )}>
-                    <label class="cursor-pointer ml-1 text-black/50 text-sm" for="typeChoice2">Private</label>
+                    <input
+                      class="cursor-pointer text-orange-500 t-private-room"
+                      type="radio"
+                      id="typeChoice2"
+                      name="new_room[type]"
+                      value="request"
+                      phx-click={
+                        JS.dispatch("room:switch-type",
+                          to: "#typeChoice2",
+                          detail: %{
+                            description:
+                              "Private Room is visible for everyone. Anyone can send request and join if approved by a room member",
+                            id: "roomTypeDescription"
+                          }
+                        )
+                      }
+                    />
+                    <label class="cursor-pointer ml-1 text-black/50 text-sm" for="typeChoice2">
+                      Private
+                    </label>
                   </a>
                   <a class="inline">
-                    <input class="cursor-pointer text-orange-500 t-secret-room" type="radio" id="typeChoice3" name="new_room[type]" value="private"
-                           phx-click={JS.dispatch("room:switch-type",
-                                        to: "#typeChoice3",
-                                        detail: %{
-                                          description: "Secret Room is not visible, only invited users can join",
-                                          id: "roomTypeDescription"
-                                        }
-                                      )}>
-                    <label class="cursor-pointer ml-1 text-black/50 text-sm" for="typeChoice3">Secret</label>
+                    <input
+                      class="cursor-pointer text-orange-500 t-secret-room"
+                      type="radio"
+                      id="typeChoice3"
+                      name="new_room[type]"
+                      value="private"
+                      phx-click={
+                        JS.dispatch("room:switch-type",
+                          to: "#typeChoice3",
+                          detail: %{
+                            description:
+                              "Secret Room is not visible, only invited users can join",
+                            id: "roomTypeDescription"
+                          }
+                        )
+                      }
+                    />
+                    <label class="cursor-pointer ml-1 text-black/50 text-sm" for="typeChoice3">
+                      Secret
+                    </label>
                   </a>
                 </div>
                 <div class="mt-5 py-1 w-full min-h-fit flex items-center justify-start border-0 rounded-lg bg-black/10">
-                  <.icon id="alert" class="basis-1/12 mr-2 w-4 h-4 fill-black/40"/>
-                  <blockquote id="roomTypeDescription" class="basis-11/12 text-xs text-black/50 mr-3">Public room is visible for everyone. Anyone can join.</blockquote>
+                  <.icon id="alert" class="basis-1/12 mr-2 w-4 h-4 fill-black/40" />
+                  <blockquote
+                    id="roomTypeDescription"
+                    class="basis-11/12 text-xs text-black/50 mr-3"
+                  >
+                    Public room is visible for everyone. Anyone can join.
+                  </blockquote>
                 </div>
-                <%= submit "Create", phx_disable_with: "Saving...", class: "w-full h-11 mt-2 text-white border-0 rounded-lg bg-grayscale flex items-center justify-center t-submit-create" %>
+                <%= submit("Create",
+                  phx_disable_with: "Saving...",
+                  class:
+                    "w-full h-11 mt-2 text-white border-0 rounded-lg bg-grayscale flex items-center justify-center t-submit-create"
+                ) %>
               </.form>
             </.modal>
-            <div class='px-7 mt-3 flex items-center justify-between'>
+            <div class="px-7 mt-3 flex items-center justify-between">
               <h5 class="channel-block-text text-grayscale" style="font-size: 22px;">Rooms</h5>
-              <button id="room-create-toggle" class="w-5 h-5 border rounded-full flex items-center justify-center t-sidebar-create-room" style="background: linear-gradient(135deg, #611E87 0%, #A75B63 100%);" phx-click={show_modal("create-room-popup")}>
-                <.icon id="add" class="w-3 h-3 flex fill-white"/>
+              <button
+                id="room-create-toggle"
+                class="w-5 h-5 border rounded-full flex items-center justify-center t-sidebar-create-room"
+                style="background: linear-gradient(135deg, #611E87 0%, #A75B63 100%);"
+                phx-click={show_modal("create-room-popup")}
+              >
+                <.icon id="add" class="w-3 h-3 flex fill-white" />
               </button>
             </div>
             <div class="w-full mt-6 flex flex-col items-start">
-              <div phx-click={JS.toggle(to: "#confirmed-rooms", in: "fade-in-scale", out: "fade-out-scale")} class="px-7 mt-3 flex items-center">
-                <.icon id="arrowDown" class="w-4 h-4 flex fill-black"/>
+              <div
+                phx-click={
+                  JS.toggle(to: "#confirmed-rooms", in: "fade-in-scale", out: "fade-out-scale")
+                }
+                class="px-7 mt-3 flex items-center"
+              >
+                <.icon id="arrowDown" class="w-4 h-4 flex fill-black" />
                 <span class="ml-1 text-sm  font-bold cursor-pointer">Confirmed</span>
               </div>
               <div class="mt-3 w-full ml-6 md:ml-10 t-confirmed-rooms" id="confirmed-rooms">
@@ -479,47 +811,76 @@
                       <li
                         phx-click="room/switch"
                         phx-value-room={room.hash}
-                        class={classes("hidden sm:flex w-full h-9 flex items-center cursor-pointer hover:bg-stone250", %{"bg-stone250" => @room && room.pub_key == @room.pub_key})}
+                        class={
+                          classes(
+                            "hidden sm:flex w-full h-9 flex items-center cursor-pointer hover:bg-stone250",
+                            %{"bg-stone250" => @room && room.pub_key == @room.pub_key}
+                          )
+                        }
                       >
                         <a>
                           <div class="flex flex-row px-2">
-                            <tt class="text-sm tracking-tighter text-grayscale600">[<%= short_hash(room.hash) %>]</tt>
-                            <div class={classes("ml-1 text-sm", %{"text-fuchsia-900" => (@room && room.pub_key == @room.pub_key)} )}><%= room.name %></div>
+                            <tt class="text-sm tracking-tighter text-grayscale600">
+                              [<%= short_hash(room.hash) %>]
+                            </tt>
+                            <div class={
+                              classes("ml-1 text-sm", %{
+                                "text-fuchsia-900" => @room && room.pub_key == @room.pub_key
+                              })
+                            }>
+                              <%= room.name %>
+                            </div>
                           </div>
                         </a>
                         <%= if room.type == :request do %>
-                        <.icon id="private" class="w-5 h-5 stroke-black" />
+                          <.icon id="private" class="w-5 h-5 stroke-black" />
                         <% end %>
                         <%= if room.type == :private do %>
-                        <.icon id="secret" class="w-4 h-4" />
+                          <.icon id="secret" class="w-4 h-4" />
                         <% end %>
                         <%= if room.type == :public do %>
-                        <.icon id="open" class="w-4 h-4" />
+                          <.icon id="open" class="w-4 h-4" />
                         <% end %>
                       </li>
-                      <li phx-click={JS.push("room/switch") |> open_content()} phx-value-room={room.hash} class={classes("sm:hidden w-full h-9 flex items-center cursor-pointer hover:bg-stone250", %{"bg-stone250" => room == @room})}>
+                      <li
+                        phx-click={JS.push("room/switch") |> open_content()}
+                        phx-value-room={room.hash}
+                        class={
+                          classes(
+                            "sm:hidden w-full h-9 flex items-center cursor-pointer hover:bg-stone250",
+                            %{"bg-stone250" => room == @room}
+                          )
+                        }
+                      >
                         <a>
                           <div class="flex flex-row pl-7">
-                            <tt class="text-sm tracking-tighter text-grayscale600">[<%= short_hash(room.hash) %>]</tt>
+                            <tt class="text-sm tracking-tighter text-grayscale600">
+                              [<%= short_hash(room.hash) %>]
+                            </tt>
                             <div class="ml-1 text-sm"><%= room.name %></div>
                           </div>
                         </a>
-                          <%= if room.type == :request do %>
-                        <.icon id="private" class="w-5 h-5 stroke-black" />
+                        <%= if room.type == :request do %>
+                          <.icon id="private" class="w-5 h-5 stroke-black" />
                         <% end %>
                         <%= if room.type == :private do %>
-                        <.icon id="secret" class="w-4 h-4" />
+                          <.icon id="secret" class="w-4 h-4" />
                         <% end %>
                         <%= if room.type == :public do %>
-                        <.icon id="open" class="w-4 h-4" />
+                          <.icon id="open" class="w-4 h-4" />
                         <% end %>
                       </li>
                     <% end %>
                   <% end %>
                 </ul>
               </div>
-              <div phx-click={JS.toggle(to: "#unconfirmed-rooms", in: "fade-in-scale", out: "fade-out-scale")} class="px-7 mt-3 flex items-center">
-                <.icon id="arrowDown" class="w-4 h-4 flex fill-black"/>
+              <div
+                phx-click={
+                  JS.toggle(to: "#unconfirmed-rooms", in: "fade-in-scale", out: "fade-out-scale")
+                }
+                class="px-7 mt-3 flex items-center"
+              >
+                <.icon id="arrowDown" class="w-4 h-4 flex fill-black" />
                 <span class="ml-1 text-sm  font-bold cursor-pointer">Not Confirmed</span>
               </div>
               <div id="unconfirmed-rooms" class="mt-3 w-full t-unconfirmed-rooms">
@@ -532,16 +893,24 @@
                         <li class="w-full h-9 cursor-pointer flex items-center hover:bg-stone250">
                           <div class="flex flex-row justify-between px-7 w-full">
                             <div class="flex flex-row">
-                              <tt class="text-sm tracking-tighter text-grayscale600">[<%= short_hash(room.hash) %>]</tt>
+                              <tt class="text-sm tracking-tighter text-grayscale600">
+                                [<%= short_hash(room.hash) %>]
+                              </tt>
                               <div class="ml-1 text-sm"><%= room.name %></div>
                             </div>
-                            <.icon id="time" class="w-4 h-4 flex fill-black/50"/>
+                            <.icon id="time" class="w-4 h-4 flex fill-black/50" />
                           </div>
                         </li>
                       <% else %>
-                        <li class="w-full h-9 cursor-pointer flex items-center hover:bg-stone250" phx-click="room/send-request" phx-value-room={room.hash}>
+                        <li
+                          class="w-full h-9 cursor-pointer flex items-center hover:bg-stone250"
+                          phx-click="room/send-request"
+                          phx-value-room={room.hash}
+                        >
                           <div class="flex flex-row px-7 w-full">
-                            <tt class="text-sm tracking-tighter text-grayscale600">[<%= short_hash(room.hash) %>]</tt>
+                            <tt class="text-sm tracking-tighter text-grayscale600">
+                              [<%= short_hash(room.hash) %>]
+                            </tt>
                             <div class="ml-1 text-sm"><%= room.name %></div>
                           </div>
                         </li>
@@ -556,9 +925,12 @@
             <%= unless @room do %>
               <div class="my-auto mx-auto flex flex-col items-center justify-center w-80 h-32 border-9 rounded-lg bg-white/20">
                 <span class="my-2 text-sm text-white">Select any Room or create your own</span>
-                <button phx-click={show_modal("create-room-popup")} class="my-2 flex flex-row items-center justify-center border rounded-lg border-white w-72 h-11 t-create-room">
+                <button
+                  phx-click={show_modal("create-room-popup")}
+                  class="my-2 flex flex-row items-center justify-center border rounded-lg border-white w-72 h-11 t-create-room"
+                >
                   <span class="text-sm text-white">Create Room</span>
-                  <.icon id="add" class="w-4 h-4 flex fill-white"/>
+                  <.icon id="add" class="w-4 h-4 flex fill-white" />
                 </button>
               </div>
             <% else %>
@@ -567,76 +939,128 @@
                 id="chatContent"
                 class="basis-[93%] pb-1 md:pb-0 overflow-y-scroll flex flex-col justify-between relative a-content-block t-chat-content"
                 id={"room-#{@room.admin_hash}"}
-                phx-hook="Chat" data-page={@page}
+                phx-hook="Chat"
+                data-page={@page}
                 data-has-more-messages={"#{@has_more_messages}"}
               >
-
-                <div phx-click={JS.dispatch("phx:scroll-to-bottom")} class={classes("w-full px-8 border-b border-white/10 backdrop-blur-md bg-black/20 z-10 flex flex-row items-center justify-between sticky top-0 right-0")} style="min-height: 56px;" >
+                <div
+                  phx-click={JS.dispatch("phx:scroll-to-bottom")}
+                  class={
+                    classes(
+                      "w-full px-8 border-b border-white/10 backdrop-blur-md bg-black/20 z-10 flex flex-row items-center justify-between sticky top-0 right-0"
+                    )
+                  }
+                  style="min-height: 56px;"
+                >
                   <div class="flex flex-row items-center">
-                    <button phx-click={JS.push("room/close") |> close_content()} class="sm:hidden pr-3">
-                      <.icon id="arrowBack" class="w-6 h-6 fill-white"/>
+                    <button
+                      phx-click={JS.push("room/close") |> close_content()}
+                      class="sm:hidden pr-3"
+                    >
+                      <.icon id="arrowBack" class="w-6 h-6 fill-white" />
                     </button>
-                     <%= if @room.type == :public do %>
-                    <.icon id="open" class="w-4 h-4 fill-white" />
-                     <% end %>
-                     <%= if @room.type == :private do %>
-                    <.icon id="secret" class="w-4 h-4 fill-white"/>
-                     <% end %>
-                     <%= if @room.type == :request do %>
-                    <.icon id="private" class="w-5 h-5 stroke-white"/>
-                     <% end %>
+                    <%= if @room.type == :public do %>
+                      <.icon id="open" class="w-4 h-4 fill-white" />
+                    <% end %>
+                    <%= if @room.type == :private do %>
+                      <.icon id="secret" class="w-4 h-4 fill-white" />
+                    <% end %>
+                    <%= if @room.type == :request do %>
+                      <.icon id="private" class="w-5 h-5 stroke-white" />
+                    <% end %>
                     <div class="text-base text-white">[<%= short_hash(@room.admin_hash) %>]</div>
-                    <h1 class="ml-1 text-base font-bolt text-white" ><%= @room.name %></h1>
+                    <h1 class="ml-1 text-base font-bolt text-white"><%= @room.name %></h1>
                   </div>
                   <div class="flex flex-row justify-between">
                     <%= if @room.type == :request do %>
-                      <button class="mr-4 flex items-center" phx-click={if @room_requests == [], do: nil, else: show_modal("room-request-list")}>
-                        <.icon id="requestList" class="w-4 h-4 mr-1 z-20 stroke-white fill-white"/>
+                      <button
+                        class="mr-4 flex items-center"
+                        phx-click={
+                          if @room_requests == [], do: nil, else: show_modal("room-request-list")
+                        }
+                      >
+                        <.icon id="requestList" class="w-4 h-4 mr-1 z-20 stroke-white fill-white" />
                         <span class="text-base text-white">Requests</span>
                       </button>
                     <% end %>
-                    <button class="flex items-center t-invite-btn" phx-click={if Chat.User.list() |> length == 1, do: nil, else: show_modal("room-invite-list")}>
-                      <.icon id="share" class="w-4 h-4 mr-1 z-20 fill-white"/>
+                    <button
+                      class="flex items-center t-invite-btn"
+                      phx-click={
+                        if Chat.User.list() |> length == 1,
+                          do: nil,
+                          else: show_modal("room-invite-list")
+                      }
+                    >
+                      <.icon id="share" class="w-4 h-4 mr-1 z-20 fill-white" />
                       <span class="text-base text-white"> Invite</span>
                     </button>
                   </div>
-
                 </div>
 
-
                 <%= if @room.type == :request do %>
-                  <.modal id="room-request-list"  class="z-30">
+                  <.modal id="room-request-list" class="z-30">
                     <h1 class="text-base font-bold text-grayscale">Requests</h1>
                     <div class="mt-3 w-full flex flex-col">
                       <%= for user <- @room_requests do %>
-                        <div id={"user-#{user.hash}"} class="flex flex-row items-center justify-between">
+                        <div
+                          id={"user-#{user.hash}"}
+                          class="flex flex-row items-center justify-between"
+                        >
                           <div class="inline-flex">
-                            <div class="font-bold text-sm text-purple">[<%= short_hash(user.hash) %>]</div>
+                            <div class="font-bold text-sm text-purple">
+                              [<%= short_hash(user.hash) %>]
+                            </div>
                             <div class="ml-1 font-bold text-sm text-purple"><%= user.name %></div>
                           </div>
-                          <a class="text-black/50" phx-click={JS.push("room/approve-request") |> JS.dispatch("chat:toggle", to: "#user-#{user.hash}", detail: %{class: "hidden"})} phx-value-hash={user.hash}>Approve</a>
+                          <a
+                            class="text-black/50"
+                            phx-click={
+                              JS.push("room/approve-request")
+                              |> JS.dispatch("chat:toggle",
+                                to: "#user-#{user.hash}",
+                                detail: %{class: "hidden"}
+                              )
+                            }
+                            phx-value-hash={user.hash}
+                          >
+                            Approve
+                          </a>
                         </div>
                       <% end %>
                     </div>
                   </.modal>
                 <% end %>
-                <.modal id="room-invite-list"  class="z-30">
-                  <h1 class="text-base font-bold text-grayscale t-invite-header">Invite to the Room</h1>
+                <.modal id="room-invite-list" class="z-30">
+                  <h1 class="text-base font-bold text-grayscale t-invite-header">
+                    Invite to the Room
+                  </h1>
                   <div class="mt-3 w-full flex flex-col">
                     <%= for user <- Chat.User.list() do %>
                       <%= unless user.hash == @my_id do %>
-                        <div id={"user-#{user.hash}"} class="flex flex-row items-center justify-between t-invite">
+                        <div
+                          id={"user-#{user.hash}"}
+                          class="flex flex-row items-center justify-between t-invite"
+                        >
                           <div class="inline-flex">
-                            <div class="text-sm text-black/50">[<%= short_hash(user.hash) %>]</div>
+                            <div class="text-sm text-black/50">
+                              [<%= short_hash(user.hash) %>]
+                            </div>
                             <div class="ml-1 text-sm"><%= user.name %></div>
                           </div>
-                          <a class="flex items-center justify-between" phx-click={JS.push("room/invite-user")
-                                                                                  |> JS.dispatch("chat:toggle", to: "#user-#{user.hash}", detail: %{class: "hidden"})
-                                                                                  |> JS.show(to: "#inviteSentNotification", display: "flex")
-                                                                                }
-                                                                      phx-value-hash={user.hash}>
+                          <a
+                            class="flex items-center justify-between"
+                            phx-click={
+                              JS.push("room/invite-user")
+                              |> JS.dispatch("chat:toggle",
+                                to: "#user-#{user.hash}",
+                                detail: %{class: "hidden"}
+                              )
+                              |> JS.show(to: "#inviteSentNotification", display: "flex")
+                            }
+                            phx-value-hash={user.hash}
+                          >
                             <p class="text-purple font-semibold">Send invite</p>
-                            <.icon id="send" class="w-4 h-4 ml-2 z-20 fill-purple"/>
+                            <.icon id="send" class="w-4 h-4 ml-2 z-20 fill-purple" />
                           </a>
                         </div>
                       <% end %>
@@ -646,28 +1070,40 @@
                 <div>
                   <div id="chat-messages" phx-update={@message_update_mode}>
                     <%= for msg <- @messages do %>
-                      <Layout.Message.message_block chat_type={:room} msg={msg} my_id={@my_id} room={@room} timezone={@timezone} />
+                      <Layout.Message.message_block
+                        chat_type={:room}
+                        msg={msg}
+                        my_id={@my_id}
+                        room={@room}
+                        timezone={@timezone}
+                      />
                     <% end %>
                   </div>
                   <div class="px-2 sm:px-8" phx-update="replace" id="ddd">
                     <%= for %{valid?: true} = entry <- @uploads.room_image.entries do %>
                       <div id={"upload#{entry.uuid}"} class="m-1 flex justify-end">
                         <div class="flex-col max-w-xxs sm:max-w-md min-w-[180px]">
-                          <%= live_img_preview entry, class: "blur-sm animate-pulse" %>
+                          <%= live_img_preview(entry, class: "blur-sm animate-pulse") %>
 
-                            <div class="w-full bg-gray-200 h-2 dark:bg-gray-700">
-                              <div class="bg-gray-600 h-2 dark:bg-gray-300" style={"width: #{entry.progress}%"}></div>
+                          <div class="w-full bg-gray-200 h-2 dark:bg-gray-700">
+                            <div
+                              class="bg-gray-600 h-2 dark:bg-gray-300"
+                              style={"width: #{entry.progress}%"}
+                            >
                             </div>
+                          </div>
                         </div>
                       </div>
                     <% end %>
                     <%= for %{valid?: true} = entry <- @uploads.room_file.entries do %>
                       <div id={"upload#{entry.uuid}"} class="m-1 flex justify-end">
                         <div class="bg-purple50 max-w-xxs sm:max-w-md min-w-[180px] rounded-lg flex items-center justify-between">
-                          <.icon id="document" class="w-14 h-14 flex fill-black/50 animate-pulse"/>
+                          <.icon id="document" class="w-14 h-14 flex fill-black/50 animate-pulse" />
                           <div class="w-36 flex flex-col pr-3">
                             <span class="truncate text-xs"><%= entry.client_name %></span>
-                            <div class="text-xs text-black/50"><%= entry.progress %>% uploaded</div>
+                            <div class="text-xs text-black/50">
+                              <%= entry.progress %>% uploaded
+                            </div>
                           </div>
                         </div>
                       </div>
@@ -684,33 +1120,46 @@
                     phx-change="room/import-files"
                     phx-drop-target={@uploads.room_file.ref}
                   >
-                    <%= live_file_input @uploads.room_file, style: "display: none"  %>
+                    <%= live_file_input(@uploads.room_file, style: "display: none") %>
                   </.form>
-                  <button class="relative t-attach-file" id="attachFileBtn" phx-click={JS.dispatch("click", to: "#room-file-form input[type=file]")}>
-                    <.icon id="attach" class="w-7 h-7 flex fill-white"/>
+                  <button
+                    class="relative t-attach-file"
+                    id="attachFileBtn"
+                    phx-click={JS.dispatch("click", to: "#room-file-form input[type=file]")}
+                  >
+                    <.icon id="attach" class="w-7 h-7 flex fill-white" />
                   </button>
                   <.form
-                    let={di}
+                    :let={di}
                     for={:room}
                     id="room-form"
                     class="basis-[99%] flex items-center justify-between"
                     phx-change={JS.dispatch("chat:set-input-size", to: "#room-input")}
-                    phx-submit={JS.push("room/text-message") |> JS.dispatch("chat:clear-value", to: "#room-input") |> JS.dispatch("chat:set-input-size", to: "#room-input")}
+                    phx-submit={
+                      JS.push("room/text-message")
+                      |> JS.dispatch("chat:clear-value", to: "#room-input")
+                      |> JS.dispatch("chat:set-input-size", to: "#room-input")
+                    }
                     onkeydown="
                       if (event.key == 'Enter' && event.shiftKey) {
                         document.getElementById('room-form-submit-button').click()
                       }
                     "
                   >
-                    <%= textarea di, :text,
+                    <%= textarea(di, :text,
                       placeholder: "Enter message",
-                      class: "w-full h-10 resize-none border-0 overflow-y-auto text-black placeholder-black/50 focus:ring-0 t-room-input",
+                      class:
+                        "w-full h-10 resize-none border-0 overflow-y-auto text-black placeholder-black/50 focus:ring-0 t-room-input",
                       id: "room-input",
                       spellcheck: "false",
                       autocomplete: "off"
-                    %>
-                    <button id="room-form-submit-button" class="t-room-send-message-btn" type="submit">
-                      <.icon id="send" class="w-7 h-7 flex fill-purple"/>
+                    ) %>
+                    <button
+                      id="room-form-submit-button"
+                      class="t-room-send-message-btn"
+                      type="submit"
+                    >
+                      <.icon id="send" class="w-7 h-7 flex fill-purple" />
                     </button>
                   </.form>
                 <% end %>
@@ -719,59 +1168,81 @@
                     <div class="flex items-center justify-between pb-2 mt-2">
                       <div class="w-[95%]">
                         <h1 class="text-purple t-edit">Editing</h1>
-                        <span class="truncate block text-xs text-black/50"><%= @edit_content %></span>
+                        <span class="truncate block text-xs text-black/50">
+                          <%= @edit_content %>
+                        </span>
                       </div>
-                      <button type="button" class="t-cancel-edit" phx-click="room/cancel-edit" >
-                        <.icon id="close" class="w-7 h-7 flex fill-black/50"/>
+                      <button type="button" class="t-cancel-edit" phx-click="room/cancel-edit">
+                        <.icon id="close" class="w-7 h-7 flex fill-black/50" />
                       </button>
                     </div>
                     <.form
-                      let={dei}
+                      :let={dei}
                       for={:room_edit}
                       id="rooom-edit-form"
                       class="flex items-center justify-start "
                       phx-change={JS.dispatch("chat:set-input-size", to: "#room-input")}
-                      phx-submit={JS.push("room/edited-message") |> JS.dispatch("chat:clear-value", to: "#room-input") |> JS.dispatch("chat:set-input-size", to: "#room-input")}
+                      phx-submit={
+                        JS.push("room/edited-message")
+                        |> JS.dispatch("chat:clear-value", to: "#room-input")
+                        |> JS.dispatch("chat:set-input-size", to: "#room-input")
+                      }
                       onkeydown="
                       if (event.key == 'Enter' && event.shiftKey) {
                         document.getElementById('room-edit-form-submit-button').click()
                       }
-                      ">
-                      <%= textarea dei, :text,
-                            class: "w-full px-0 resize-none outline-none border-0 overflow-scroll text-black placeholder-black/50 focus:ring-0 t-room-edit-input",
-                            id: "room-edit-input",
-                            spellcheck: "false",
-                            autocomplete: "off",
-                            value: @edit_content
-                      %>
+                      "
+                    >
+                      <%= textarea(dei, :text,
+                        class:
+                          "w-full px-0 resize-none outline-none border-0 overflow-scroll text-black placeholder-black/50 focus:ring-0 t-room-edit-input",
+                        id: "room-edit-input",
+                        spellcheck: "false",
+                        autocomplete: "off",
+                        value: @edit_content
+                      ) %>
                       <button id="room-edit-form-submit-button" type="submit">
-                        <.icon id="send" class="w-7 h-7 flex fill-purple t-room-edit-send-btn"/>
+                        <.icon id="send" class="w-7 h-7 flex fill-purple t-room-edit-send-btn" />
                       </button>
                     </.form>
                   </div>
                 <% end %>
                 <%= if @room_mode == :select do %>
                   <div class="w-full h-11 bg-white flex justify-between items-center">
-                    <button id="delete-btn" class="cursor-pointer inline-flex items-center disabled:pointer-events-none t-delete-room-msg-btn"
-                      phx-click={show_modal("delete-messages-popup")
-                                |> JS.set_attribute({"phx-click", hide_modal("delete-messages-popup")
-                                                                  |> JS.push("room/delete-messages")
-                                                                  |> stringify_commands()},
-                                                                  to: "#delete-messages-popup .deleteMessageButton")
-                                |> JS.dispatch("chat:messages-to-delete", to: "#delete-messages-popup") }
+                    <button
+                      id="delete-btn"
+                      class="cursor-pointer inline-flex items-center disabled:pointer-events-none t-delete-room-msg-btn"
+                      phx-click={
+                        show_modal("delete-messages-popup")
+                        |> JS.set_attribute(
+                          {"phx-click",
+                           hide_modal("delete-messages-popup")
+                           |> JS.push("room/delete-messages")
+                           |> stringify_commands()},
+                          to: "#delete-messages-popup .deleteMessageButton"
+                        )
+                        |> JS.dispatch("chat:messages-to-delete", to: "#delete-messages-popup")
+                      }
                     >
-                      <.icon id="delete" class="w-4 h-4 flex fill-black x-icon"/>
+                      <.icon id="delete" class="w-4 h-4 flex fill-black x-icon" />
                       <span id="delete-span">Delete</span>
                     </button>
 
-                    <button id="download-btn" class="cursor-pointer inline-flex items-center t-download-room-msg-btn"
-                    phx-click={JS.dispatch("chat:download-messages", to: "#chatContent", detail: %{chatType: "room"})}>
+                    <button
+                      id="download-btn"
+                      class="cursor-pointer inline-flex items-center t-download-room-msg-btn"
+                      phx-click={
+                        JS.dispatch("chat:download-messages",
+                          to: "#chatContent",
+                          detail: %{chatType: "room"}
+                        )
+                      }
+                    >
                       <span class="text-purple">Download</span>
-                      <.icon id="download" class="ml-1 w-4 h-4 flex  stroke-purple "/>
+                      <.icon id="download" class="ml-1 w-4 h-4 flex  stroke-purple " />
                     </button>
                   </div>
                 <% end %>
-
               </div>
             <% end %>
           </div>
@@ -779,14 +1250,26 @@
         <%= if @lobby_mode == :feeds do %>
           <div id="contentContainer" class="hidden sm:flex flex flex-col contentContainer">
             <div class="overflow-y-auto flex flex-col justify-between t-feedsBlock">
-              <div class="h-14 w-full px-8 border-b border-white/10 backdrop-blur-md bg-white/10 z-10 flex flex-row items-center justify-start fixed" >
-                <a class="sm:hidden mr-2" phx-value-lobby-mode="chats" phx-click={JS.push("switch-lobby-mode") |> JS.push("close-feeds") |> close_content()}><.icon id="arrowBack" class="w-6 h-6 fill-white"/></a>
+              <div class="h-14 w-full px-8 border-b border-white/10 backdrop-blur-md bg-white/10 z-10 flex flex-row items-center justify-start fixed">
+                <a
+                  class="sm:hidden mr-2"
+                  phx-value-lobby-mode="chats"
+                  phx-click={
+                    JS.push("switch-lobby-mode") |> JS.push("close-feeds") |> close_content()
+                  }
+                >
+                  <.icon id="arrowBack" class="w-6 h-6 fill-white" />
+                </a>
                 <h1 class="ml-1 text-base font-bolt text-white">Feeds</h1>
                 <div class="ml-3 text-white/50">
                   [ <%= @version %> ]
                 </div>
               </div>
-              <div class="mt-16 mb-8 px-4 sm:px-8 w-full t-feed-list" id="action-feed-list" phx-update={@feed_update_mode}>
+              <div
+                class="mt-16 mb-8 px-4 sm:px-8 w-full t-feed-list"
+                id="action-feed-list"
+                phx-update={@feed_update_mode}
+              >
                 <%= if @action_feed_list do %>
                   <%= for item <- @action_feed_list do %>
                     <div class="py-1 flex justify-start" id={"item-#{UUID.uuid4()}"}>
@@ -796,10 +1279,15 @@
                 <% end %>
               </div>
               <%= if @action_feed_till > 1 do %>
-                <div class="mb-10 px-4 flex flex-row items-center justify-between" >
-                  <hr class="basis-[35%] sm:basis-[45%] border-1 border-white/10">
-                  <a class="basis-[30%] sm:basis-[20%] text-center cursor-pointer text-white/50 t-load-more" phx-click="feed-more">load more</a>
-                  <hr class="basis-[35%] sm:basis-[45%] border-1 border-white/10">
+                <div class="mb-10 px-4 flex flex-row items-center justify-between">
+                  <hr class="basis-[35%] sm:basis-[45%] border-1 border-white/10" />
+                  <a
+                    class="basis-[30%] sm:basis-[20%] text-center cursor-pointer text-white/50 t-load-more"
+                    phx-click="feed-more"
+                  >
+                    load more
+                  </a>
+                  <hr class="basis-[35%] sm:basis-[45%] border-1 border-white/10" />
                 </div>
               <% end %>
             </div>
@@ -824,24 +1312,30 @@
           <Layout.Admin.container>
             <Layout.Admin.row>
               <Layout.Admin.block title="WiFi settings">
-
                 <%= if @wifi_loaded do %>
-                  <.form
-                    for={:admin_wifi}
-                    id="admin-wifi-form"
-                    phx-submit="admin/wifi-submit"
-                  >
+                  <.form for={:admin_wifi} id="admin-wifi-form" phx-submit="admin/wifi-submit">
                     <section class="p-2 pb-0 text-right">
-                      SSID: <input name="ssid" class="p-1.5 rounded bg-white/50" type="text" value={@wifi_ssid}>
+                      SSID:
+                      <input
+                        name="ssid"
+                        class="p-1.5 rounded bg-white/50"
+                        type="text"
+                        value={@wifi_ssid}
+                      />
                     </section>
                     <section class="p-2 pb-1 text-right">
-                      Password: <input name="password" class="p-1.5 rounded bg-white/50" type="text" value={@wifi_password}>
+                      Password:
+                      <input
+                        name="password"
+                        class="p-1.5 rounded bg-white/50"
+                        type="text"
+                        value={@wifi_password}
+                      />
                     </section>
                     <section class="text-center">
-                      <button
-                        type="submit"
-                        class="bg-red-500 px-4 py-2 mt-1 text-white rounded"
-                      >Update</button>
+                      <button type="submit" class="bg-red-500 px-4 py-2 mt-1 text-white rounded">
+                        Update
+                      </button>
                     </section>
                   </.form>
                 <% else %>
@@ -849,10 +1343,8 @@
                     loading ...
                   </section>
                 <% end %>
-
               </Layout.Admin.block>
               <Layout.Admin.block title="Maintenance">
-
                 <section>
                   <Layout.Admin.db_status status={@db_status} />
                   <Layout.Admin.unmount_main_button mode={@db_status.mode} />
@@ -860,74 +1352,83 @@
                 <section class="p-2 text-grayscale600">
                   <a href="#" phx-click="admin/device-log">Device Log</a>
                 </section>
-
               </Layout.Admin.block>
             </Layout.Admin.row>
             <Layout.Admin.row>
               <Layout.Admin.block title="Admin List">
-
                 <section>
                   <%= for admin <- @admin_list do %>
                     <div><%= admin.name %></div>
                   <% end %>
                 </section>
-
               </Layout.Admin.block>
               <Layout.Admin.block title="Invite new one">
-
                 <section>
                   <%= for user <- @user_list do %>
                     <div
                       class="cursor-pointer"
-                      phx-click={show_modal("invite-user-confirmation")
-                                  |> JS.set_attribute({"phx-click", hide_modal("invite-user-confirmation")
-                                                                    |> JS.push("admin/invite-new-user")
-                                                                    |> stringify_commands()
-                                                    }, to: ".confirmButton")
-                                  |> JS.set_attribute({"phx-value-hash", user.hash}, to: ".confirmButton")
-                                }
-                    ><%= user.name %></div>
+                      phx-click={
+                        show_modal("invite-user-confirmation")
+                        |> JS.set_attribute(
+                          {"phx-click",
+                           hide_modal("invite-user-confirmation")
+                           |> JS.push("admin/invite-new-user")
+                           |> stringify_commands()},
+                          to: ".confirmButton"
+                        )
+                        |> JS.set_attribute({"phx-value-hash", user.hash}, to: ".confirmButton")
+                      }
+                    >
+                      <%= user.name %>
+                    </div>
                   <% end %>
                 </section>
-
               </Layout.Admin.block>
             </Layout.Admin.row>
             <Layout.Admin.row>
               <Layout.Admin.block title="Remove Room">
-
                 <section>
                   <%= for room <- @room_list do %>
                     <div
                       class="cursor-pointer"
-                      phx-click={show_modal("remove-room-confirmation")
-                                  |> JS.set_attribute({"phx-click", hide_modal("remove-room-confirmation")
-                                                                    |> JS.push("admin/remove-room")
-                                                                    |> stringify_commands()
-                                                      }, to: ".confirmButton")
-                                  |> JS.set_attribute({"phx-value-hash", room.hash}, to: ".confirmButton")
-                                }
-                    ><%= room.name %></div>
+                      phx-click={
+                        show_modal("remove-room-confirmation")
+                        |> JS.set_attribute(
+                          {"phx-click",
+                           hide_modal("remove-room-confirmation")
+                           |> JS.push("admin/remove-room")
+                           |> stringify_commands()},
+                          to: ".confirmButton"
+                        )
+                        |> JS.set_attribute({"phx-value-hash", room.hash}, to: ".confirmButton")
+                      }
+                    >
+                      <%= room.name %>
+                    </div>
                   <% end %>
                 </section>
-
               </Layout.Admin.block>
               <Layout.Admin.block title="Remove User">
-
                 <section>
                   <%= for user <- @full_user_list do %>
                     <div
                       class="cursor-pointer"
-                      phx-click={show_modal("remove-user-confirmation")
-                                  |> JS.set_attribute({"phx-click", hide_modal("remove-user-confirmation")
-                                                                    |> JS.push("admin/remove-user")
-                                                                    |> stringify_commands()
-                                                    }, to: ".confirmButton")
-                                  |> JS.set_attribute({"phx-value-hash", user.hash}, to: ".confirmButton")
-                                }
-                    ><%= user.name %></div>
+                      phx-click={
+                        show_modal("remove-user-confirmation")
+                        |> JS.set_attribute(
+                          {"phx-click",
+                           hide_modal("remove-user-confirmation")
+                           |> JS.push("admin/remove-user")
+                           |> stringify_commands()},
+                          to: ".confirmButton"
+                        )
+                        |> JS.set_attribute({"phx-value-hash", user.hash}, to: ".confirmButton")
+                      }
+                    >
+                      <%= user.name %>
+                    </div>
                   <% end %>
                 </section>
-
               </Layout.Admin.block>
             </Layout.Admin.row>
           </Layout.Admin.container>
@@ -935,19 +1436,27 @@
       </div>
     <% end %>
     <%= if @mode == :import_key_ring do %>
-      <img class="vectorGroup bottomVectorGroup" src="/images/bottom_vector_group.svg"/>
-      <img class="vectorGroup topVectorGroup" src="/images/top_vector_group.svg"/>
+      <img class="vectorGroup bottomVectorGroup" src="/images/bottom_vector_group.svg" />
+      <img class="vectorGroup topVectorGroup" src="/images/top_vector_group.svg" />
       <div class="flex flex-col items-center justify-center w-screen h-screen">
-        <div class="container unauthenticated" >
+        <div class="container unauthenticated">
           <div class="flex justify-center">
-            <.icon id="logo" class="w-14 h-14 flex fill-white"/>
+            <.icon id="logo" class="w-14 h-14 flex fill-white" />
           </div>
           <div class="left-0 mt-10">
-            <a phx-click="login:import-keyring-close" class="x-back-target flex items-center justify-start">
-              <.icon id="arrowLeft" class="w-4 h-4 flex fill-white/70"/>
+            <a
+              phx-click="login:import-keyring-close"
+              class="x-back-target flex items-center justify-start"
+            >
+              <.icon id="arrowLeft" class="w-4 h-4 flex fill-white/70" />
               <p class="ml-2 text-sm text-white/70">Back to Log In</p>
             </a>
-            <h1 style="font-size: 28px; line-height: 34px;" class="mt-5 font-inter font-bold text-white">Login with QR code</h1>
+            <h1
+              style="font-size: 28px; line-height: 34px;"
+              class="mt-5 font-inter font-bold text-white"
+            >
+              Login with QR code
+            </h1>
             <div>
               <p class="mt-2.5 font-inter text-sm text-white/70">
                 Scan the QR code from device where you logged in and enter the code
@@ -955,7 +1464,7 @@
               </p>
             </div>
           </div>
-          <div class="mt-5 border rounded border-white/10 rounded-xl p-10" >
+          <div class="mt-5 border rounded border-white/10 rounded-xl p-10">
             <a href={@url} target="_blank">
               <img class="w-full" src={"data:image/svg+xml;base64, #{@encoded_qr_code}"} />
             </a>
@@ -964,53 +1473,81 @@
       </div>
     <% end %>
     <%= if @mode == :export_key_ring do %>
-      <img class="vectorGroup bottomVectorGroup" src="/images/bottom_vector_group.svg"/>
-      <img class="vectorGroup topVectorGroup" src="/images/top_vector_group.svg"/>
+      <img class="vectorGroup bottomVectorGroup" src="/images/bottom_vector_group.svg" />
+      <img class="vectorGroup topVectorGroup" src="/images/top_vector_group.svg" />
       <div class="flex flex-col items-center justify-center w-screen h-screen">
-        <div class="container unauthenticated z-10" >
+        <div class="container unauthenticated z-10">
           <div class="flex justify-center">
-            <.icon id="logo" class="w-14 h-14 flex fill-white"/>
+            <.icon id="logo" class="w-14 h-14 flex fill-white" />
           </div>
           <div class="left-0 mt-10">
-            <a phx-click="login:export-code-close" class="x-back-target flex items-center justify-start">
-              <.icon id="arrowLeft" class="w-4 h-4 flex fill-white/70"/>
+            <a
+              phx-click="login:export-code-close"
+              class="x-back-target flex items-center justify-start"
+            >
+              <.icon id="arrowLeft" class="w-4 h-4 flex fill-white/70" />
               <p class="ml-2 text-sm text-white/70">Back to Log In</p>
             </a>
-            <h1 style="font-size: 28px; line-height: 34px;" class="mt-5 font-inter font-bold text-white">Login with QR code</h1>
+            <h1
+              style="font-size: 28px; line-height: 34px;"
+              class="mt-5 font-inter font-bold text-white"
+            >
+              Login with QR code
+            </h1>
             <p class="mt-2.5 font-inter text-sm text-white/50">
               Your identity and all rooms access will be copied to another client, that supplied this link and code to you.
             </p>
             <div class="mt-5">
               <%= unless @export_result do %>
                 <.form
-                  let={f}
+                  :let={f}
                   for={:export_key_ring}
                   id="export-key-form"
                   autocomplete="off"
                   phx-submit={JS.hide() |> JS.push("export-keys")}
                 >
-                  <%= text_input f, :code, placeholder: "Enter code", type: "number", min: 10, max: 99, class: "w-full  h-11 py-2.5 appearance-none block bg-transparent border border-white/50 rounded-lg text-white placeholder-white/50 focus:outline-none focus:ring-0 focus:border-white" %>
-                  <%= submit "Log In", class: "mt-2.5 w-full h-11 focus:outline-none text-white px-4 rounded-lg", style: "background-color: rgb(36, 24, 36);" %>
+                  <%= text_input(f, :code,
+                    placeholder: "Enter code",
+                    type: "number",
+                    min: 10,
+                    max: 99,
+                    class:
+                      "w-full  h-11 py-2.5 appearance-none block bg-transparent border border-white/50 rounded-lg text-white placeholder-white/50 focus:outline-none focus:ring-0 focus:border-white"
+                  ) %>
+                  <%= submit("Log In",
+                    class: "mt-2.5 w-full h-11 focus:outline-none text-white px-4 rounded-lg",
+                    style: "background-color: rgb(36, 24, 36);"
+                  ) %>
                 </.form>
               <% else %>
                 <%= if @export_result == :error do %>
-                  <div class="mt-2.5 p-2.5 w-full bg-transparent border border-white/0 rounded-lg text-white flex flex-row items-strech justify-between" style="background: #F45649;">
+                  <div
+                    class="mt-2.5 p-2.5 w-full bg-transparent border border-white/0 rounded-lg text-white flex flex-row items-strech justify-between"
+                    style="background: #F45649;"
+                  >
                     <div class="w-44  flex flex-row items-stretch justify-start">
-                      <.icon id="alert" class="w-7 h-7 mt-1 fill-white"/>
-                      <p class="ml-2" style="font-size: 14px;">The code is wrong. Fresh link needed.</p>
+                      <.icon id="alert" class="w-7 h-7 mt-1 fill-white" />
+                      <p class="ml-2" style="font-size: 14px;">
+                        The code is wrong. Fresh link needed.
+                      </p>
                     </div>
                     <button type="button">
-                      <.icon id="close" class="w-4 h-4 fill-white"/>
+                      <.icon id="close" class="w-4 h-4 fill-white" />
                     </button>
                   </div>
                 <% else %>
-                  <div class="mt-2.5 p-2.5 w-full bg-transparent border border-white/0 rounded-lg text-white flex flex-row items-strech justify-between" style="background: #6FBC7F;">
+                  <div
+                    class="mt-2.5 p-2.5 w-full bg-transparent border border-white/0 rounded-lg text-white flex flex-row items-strech justify-between"
+                    style="background: #6FBC7F;"
+                  >
                     <div class="w-44  flex flex-row items-stretch justify-start">
-                      <.icon id="checked" class="w-7 h-7 mt-1 mr-1 fill-white"/>
-                      <p class="ml-2" style="font-size: 14px;">All good. Keys have been exported.</p>
+                      <.icon id="checked" class="w-7 h-7 mt-1 mr-1 fill-white" />
+                      <p class="ml-2" style="font-size: 14px;">
+                        All good. Keys have been exported.
+                      </p>
                     </div>
                     <button type="button">
-                      <.icon id="close" class="w-4 h-4 fill-white"/>
+                      <.icon id="close" class="w-4 h-4 fill-white" />
                     </button>
                   </div>
                 <% end %>
@@ -1021,20 +1558,30 @@
       </div>
     <% end %>
     <%= if @mode == :import_own_key_ring do %>
-      <img class="vectorGroup bottomVectorGroup" src="/images/bottom_vector_group.svg"/>
-      <img class="vectorGroup topVectorGroup" src="/images/top_vector_group.svg"/>
+      <img class="vectorGroup bottomVectorGroup" src="/images/bottom_vector_group.svg" />
+      <img class="vectorGroup topVectorGroup" src="/images/top_vector_group.svg" />
       <div class="flex flex-col items-center justify-center w-screen h-screen">
-        <div class="container unauthenticated z-10" >
+        <div class="container unauthenticated z-10">
           <div class="flex justify-center">
-            <.icon id="logo" class="w-14 h-14 fill-white"/>
+            <.icon id="logo" class="w-14 h-14 fill-white" />
           </div>
           <div class="left-0 mt-10">
-            <a phx-click="login:import-own-keyring-close" class="x-back-target flex items-center justify-start">
-              <.icon id="arrowLeft" class="w-4 h-4 fill-white/70"/>
+            <a
+              phx-click="login:import-own-keyring-close"
+              class="x-back-target flex items-center justify-start"
+            >
+              <.icon id="arrowLeft" class="w-4 h-4 fill-white/70" />
               <p class="ml-2 text-sm text-white/70">Back to Log In</p>
             </a>
-            <h1 style="font-size: 28px; line-height: 34px;" class="mt-5 font-inter font-bold text-white">Import the recovery keys</h1>
-            <p class="mt-2.5 font-inter text-sm text-white/70">Please, upload the key file and enter the password for decryption</p>
+            <h1
+              style="font-size: 28px; line-height: 34px;"
+              class="mt-5 font-inter font-bold text-white"
+            >
+              Import the recovery keys
+            </h1>
+            <p class="mt-2.5 font-inter text-sm text-white/70">
+              Please, upload the key file and enter the password for decryption
+            </p>
           </div>
           <%= if @step == :initial do %>
             <div class="row">
@@ -1046,11 +1593,17 @@
                 phx-submit="login:my-keys-file-submit"
                 phx-drop-target={@uploads.my_keys_file.ref}
               >
-                <%= live_file_input @uploads.my_keys_file, style: "display: none" %>
-                <input style="background-color: rgb(36, 24, 36);" class="w-full h-11 mt-7 bg-transparent text-white py-2 px-4 border border-white/0 rounded-lg flex items-center justify-center" type="button" value="Upload Key File" onclick="event.target.parentNode.querySelector('input[type=file]').click()" >
+                <%= live_file_input(@uploads.my_keys_file, style: "display: none") %>
+                <input
+                  style="background-color: rgb(36, 24, 36);"
+                  class="w-full h-11 mt-7 bg-transparent text-white py-2 px-4 border border-white/0 rounded-lg flex items-center justify-center"
+                  type="button"
+                  value="Upload Key File"
+                  onclick="event.target.parentNode.querySelector('input[type=file]').click()"
+                />
                 <%= for entry <- @uploads.my_keys_file.entries do %>
                   <%= if entry.progress > 0 and entry.progress <= 100 do %>
-                    <progress value={entry.progress} max="100"> <%= entry.progress %>% </progress>
+                    <progress value={entry.progress} max="100"><%= entry.progress %>%</progress>
                   <% end %>
                   <%= for err <- upload_errors(@uploads.my_keys_file, entry) do %>
                     <p class="alert alert-danger"><%= err %></p>
@@ -1061,41 +1614,61 @@
           <% end %>
           <%= if @step == :decrypt do %>
             <div class="w-full h-14 mt-7 bg-transparent text-white py-2 px-2.5 border border-white/50 rounded-lg flex flex-row items-center justify-between">
-              <div class="w-44 flex flex-row items-stretch justify-start" >
-                <div class="border-white/0 bg-white/50 w-7 h-7 flex items-center justify-center" style="border-radius: 50%;">
-                  <.icon id="check" class="w-4 h-4 stroke-white fill-white/0"/>
+              <div class="w-44 flex flex-row items-stretch justify-start">
+                <div
+                  class="border-white/0 bg-white/50 w-7 h-7 flex items-center justify-center"
+                  style="border-radius: 50%;"
+                >
+                  <.icon id="check" class="w-4 h-4 stroke-white fill-white/0" />
                 </div>
                 <div class="ml-2" style="line-height: 12px;">
                   <p style="font-size: 14px;"><%= @filename %></p>
                   <p class="text-xs text-white/50">uploaded</p>
                 </div>
               </div>
-              <button class="w-20 h-9 p-1.5 flex items-center justify-between border rounded-lg bg-white/20 border-white/0 " phx-click="login:import-own-keyring-reupload">
+              <button
+                class="w-20 h-9 p-1.5 flex items-center justify-between border rounded-lg bg-white/20 border-white/0 "
+                phx-click="login:import-own-keyring-reupload"
+              >
                 <p style="font-size: 14px;">Delete</p>
-                <.icon id="delete" class="w-4 h-4 fill-white"/>
+                <.icon id="delete" class="w-4 h-4 fill-white" />
               </button>
             </div>
             <.form
-              let={f}
+              :let={f}
               for={:import_own_keyring_password}
               id="logout-import-own-keyring-password-form"
               phx-submit="login:import-own-keyring-decrypt"
               class="mt-2.5"
             >
-              <%= text_input f, :password, type: "password", placeholder: "Enter Password", phx_debounce: 700, class: "w-full  h-11 py-2.5 appearance-none block bg-transparent border border-white/50 rounded-lg text-white placeholder-white/50 focus:outline-none focus:ring-0 focus:border-white" %>
+              <%= text_input(f, :password,
+                type: "password",
+                placeholder: "Enter Password",
+                phx_debounce: 700,
+                class:
+                  "w-full  h-11 py-2.5 appearance-none block bg-transparent border border-white/50 rounded-lg text-white placeholder-white/50 focus:outline-none focus:ring-0 focus:border-white"
+              ) %>
               <%= if @show_invalid do %>
-                <div class="mt-2.5 p-2.5 w-full h-11 bg-transparent border border-white/0 rounded-lg text-white flex flex-row items-strech justify-between" style="background: #F45649;">
-                  <div class="w-44 flex flex-row items-stretch justify-start" >
-                    <.icon id="delete" class="w-4 h-4 mt-1 fill-white"/>
+                <div
+                  class="mt-2.5 p-2.5 w-full h-11 bg-transparent border border-white/0 rounded-lg text-white flex flex-row items-strech justify-between"
+                  style="background: #F45649;"
+                >
+                  <div class="w-44 flex flex-row items-stretch justify-start">
+                    <.icon id="delete" class="w-4 h-4 mt-1 fill-white" />
                     <p class="ml-1" style="font-size: 14px;">Password Incorrect</p>
                   </div>
                   <button type="button" phx-click="login:import-own-keyring:drop-password-error">
-                    <.icon id="close" class="w-4 h-4 fill-white"/>
+                    <.icon id="close" class="w-4 h-4 fill-white" />
                   </button>
                 </div>
               <% end %>
               <div>
-                <%= submit "Log In", phx_disable_with: "Checking...", class: "w-full h-11 mt-7 bg-transparent text-white py-2 px-4 border border-white/0 rounded-lg flex items-center justify-center", style: "background-color: rgb(36, 24, 36);" %>
+                <%= submit("Log In",
+                  phx_disable_with: "Checking...",
+                  class:
+                    "w-full h-11 mt-7 bg-transparent text-white py-2 px-4 border border-white/0 rounded-lg flex items-center justify-center",
+                  style: "background-color: rgb(36, 24, 36);"
+                ) %>
               </div>
             </.form>
           <% end %>

--- a/lib/chat_web/live/main_live/layout/admin.ex
+++ b/lib/chat_web/live/main_live/layout/admin.ex
@@ -4,26 +4,26 @@ defmodule ChatWeb.MainLive.Layout.Admin do
 
   def container(assigns) do
     ~H"""
-      <div class="flex flex-col">
-        <%= render_slot(@inner_block) %> 
-      </div>
+    <div class="flex flex-col">
+      <%= render_slot(@inner_block) %>
+    </div>
     """
   end
 
   def row(assigns) do
     ~H"""
-      <div class="flex flex-row flex-wrap m-2">
-        <%= render_slot(@inner_block) %> 
-      </div>
+    <div class="flex flex-row flex-wrap m-2">
+      <%= render_slot(@inner_block) %>
+    </div>
     """
   end
 
   def block(assigns) do
     ~H"""
-      <article class="m-4 w-50 p-4 rounded-xl bg-gray-200">
-        <header class="text-2xl bg-white/50 rounded-md p-2"><%= @title %></header>
-        <%= render_slot(@inner_block) %> 
-      </article>
+    <article class="m-4 w-50 p-4 rounded-xl bg-gray-200">
+      <header class="text-2xl bg-white/50 rounded-md p-2"><%= @title %></header>
+      <%= render_slot(@inner_block) %>
+    </article>
     """
   end
 
@@ -36,10 +36,10 @@ defmodule ChatWeb.MainLive.Layout.Admin do
     assigns = assign(assigns, flags: flags)
 
     ~H"""
-      <label class="text-black/50"> Mode: </label><span><%= @status.mode %></span><br/>
-      <label class="text-black/50"> Flags: </label><span><%= @flags %></span><br/>
-      <label class="text-black/50"> Writable: </label><span><%= @status.writable %></span><br/>
-      <label class="text-black/50"> DB compaction: </label><span><%= @status.compacting %></span><br/>
+    <label class="text-black/50"> Mode: </label><span><%= @status.mode %></span> <br />
+    <label class="text-black/50"> Flags: </label><span><%= @flags %></span> <br />
+    <label class="text-black/50"> Writable: </label><span><%= @status.writable %></span> <br />
+    <label class="text-black/50"> DB compaction: </label><span><%= @status.compacting %></span> <br />
     """
   end
 
@@ -47,14 +47,13 @@ defmodule ChatWeb.MainLive.Layout.Admin do
     ~H"""
     <%= if @mode == :main do %>
       <div>
-      <button 
-        class="mt-3 w-full h-12 border rounded-lg border-black/10"
-        phx-click="admin/unmount-main"
-      >
-      Switch to internal
-      </button>
+        <button
+          class="mt-3 w-full h-12 border rounded-lg border-black/10"
+          phx-click="admin/unmount-main"
+        >
+          Switch to internal
+        </button>
       </div>
-
     <% end %>
     """
   end

--- a/lib/chat_web/live/main_live/layout/db_status.ex
+++ b/lib/chat_web/live/main_live/layout/db_status.ex
@@ -7,98 +7,149 @@ defmodule ChatWeb.MainLive.Layout.DbStatus do
 
   def desktop(assigns) do
     ~H"""
-      <div class="sidebarIcon mb-1">
-
-        <%= if @status.mode == :internal do %>
-          <!-- Crossed DB icon -->
-            <div class="pb-2.5 pl-1.5">
-              <.icon id="crossedDataBase" class={classes("w-6 h-6 fill-gray-200", %{"fill-red-600" => @status.writable == :no})}/>
-            </div>
-        <% end %>
-        <%= if @status.mode == :main do %>
-          <!-- DB icon -->
-            <div class="pb-2.5 pl-1">
-              <.icon id="dataBase" class={classes("w-6 h-6 fill-gray-200", %{"fill-red-600" => @status.writable == :no})}/>
-            </div>
-        <% end %>
-        <%= if @status.mode == :internal_to_main do %>
-          <!-- Blinking or transparent DB icon -->
-            <div class="pb-2.5 pl-1.5">
-              <.icon id="dataBase" class={classes("w-6 h-6 fill-gray-300 animate-pulse", %{"fill-red-600" => @status.writable == :no})}/>
-            </div>
-        <% end %>
-        <%= if @status.mode == :main_to_internal do %>
-          <!-- Blinking or transparent Crossed DB icon -->
-            <div class="pb-2.5 pl-1.5">
-              <.icon id="crossedDataBase" class={classes("w-6 h-6 fill-gray-300 animate-pulse", %{"fill-red-600" => @status.writable == :no})}/>
-            </div>
-        <% end %>
-
-
-          <!-- Saving or downloading icon -->
-          <%= if @status.flags[:backup] do %>
-          <div class="pb-1 pl-3">
-            <.icon id="backUp" class={classes("w-6 h-6 fill-gray-200", %{"fill-red-600" => @status.writable == :no})}/>
-          </div>
-          <% end %>
-          <!-- Syncronization icon, like cirle arrows -->
-          <%= if @status.flags[:replication] do %>
-          <div class="pl-3">
-            <.icon id="replication" class={classes("w-6 h-6 fill-gray-200", %{"fill-red-600" => @status.writable == :no})}/>
-          </div>
-           <% end %>
-           <!-- <div class="pl-2">
+    <div class="sidebarIcon mb-1">
+      <%= if @status.mode == :internal do %>
+        <!-- Crossed DB icon -->
+        <div class="pb-2.5 pl-1.5">
+          <.icon
+            id="crossedDataBase"
+            class={classes("w-6 h-6 fill-gray-200", %{"fill-red-600" => @status.writable == :no})}
+          />
+        </div>
+      <% end %>
+      <%= if @status.mode == :main do %>
+        <!-- DB icon -->
+        <div class="pb-2.5 pl-1">
+          <.icon
+            id="dataBase"
+            class={classes("w-6 h-6 fill-gray-200", %{"fill-red-600" => @status.writable == :no})}
+          />
+        </div>
+      <% end %>
+      <%= if @status.mode == :internal_to_main do %>
+        <!-- Blinking or transparent DB icon -->
+        <div class="pb-2.5 pl-1.5">
+          <.icon
+            id="dataBase"
+            class={
+              classes("w-6 h-6 fill-gray-300 animate-pulse", %{
+                "fill-red-600" => @status.writable == :no
+              })
+            }
+          />
+        </div>
+      <% end %>
+      <%= if @status.mode == :main_to_internal do %>
+        <!-- Blinking or transparent Crossed DB icon -->
+        <div class="pb-2.5 pl-1.5">
+          <.icon
+            id="crossedDataBase"
+            class={
+              classes("w-6 h-6 fill-gray-300 animate-pulse", %{
+                "fill-red-600" => @status.writable == :no
+              })
+            }
+          />
+        </div>
+      <% end %>
+      <!-- Saving or downloading icon -->
+      <%= if @status.flags[:backup] do %>
+        <div class="pb-1 pl-3">
+          <.icon
+            id="backUp"
+            class={classes("w-6 h-6 fill-gray-200", %{"fill-red-600" => @status.writable == :no})}
+          />
+        </div>
+      <% end %>
+      <!-- Syncronization icon, like cirle arrows -->
+      <%= if @status.flags[:replication] do %>
+        <div class="pl-3">
+          <.icon
+            id="replication"
+            class={classes("w-6 h-6 fill-gray-200", %{"fill-red-600" => @status.writable == :no})}
+          />
+        </div>
+      <% end %>
+      <!-- <div class="pl-2">
               <.icon id="car" class={classes("w-6 h-6 fill-gray-200", %{"fill-red-600" => @status.writable == :no})}/>
             </div>-->
-      </div>
+    </div>
     """
   end
 
   def mobile(assigns) do
     ~H"""
-      <div  class="flex flex-row items-center pt-2 w-[63%] justify-end">
-        <%= if @status.mode == :internal do %>
-          <!-- Crossed DB icon -->
-            <div class="pb-2 pr-1">
-              <.icon id="crossedDataBase" class={classes("w-5 h-[19.5px] fill-gray-200", %{"fill-red-600" => @status.writable == :no})}/>
-            </div>
-        <% end %>
-        <%= if @status.mode == :main do %>
-          <!-- DB icon -->
-            <div class="pb-2 pr-1">
-              <.icon id="dataBase" class={classes("w-5 h-[19.5px] fill-gray-200", %{"fill-red-600" => @status.writable == :no})}/>
-            </div>
-        <% end %>
-        <%= if @status.mode == :internal_to_main do %>
-          <!-- Blinking or transparent DB icon -->
-            <div class="pb-2 pr-1">
-              <.icon id="dataBase" class={classes("w-5 h-[19.5px] fill-gray-300 animate-pulse", %{"fill-red-600" => @status.writable == :no})}/>
-            </div>
-        <% end %>
-        <%= if @status.mode == :main_to_internal do %>
-          <!-- Blinking or transparent Crossed DB icon -->
-            <div class="pb-2 pr-1">
-              <.icon id="crossedDataBase" class={classes("w-5 h-[19.5px] fill-gray-300 animate-pulse", %{"fill-red-600" => @status.writable == :no})}/>
-            </div>
-        <% end %>
-
-
-          <!-- Saving or downloading icon -->
-          <%= if @status.flags[:backup] do %>
-          <div>
-            <.icon id="backUp" class={classes("w-6 h-6 fill-gray-200", %{"fill-red-600" => @status.writable == :no})}/>
-          </div>
-          <% end %>
-          <!-- Syncronization icon, like cirle arrows -->
-          <%= if @status.flags[:replication] do %>
-          <div class="w-[21px] pt-0.5">
-            <.icon id="replication" class={classes("w-6 h-6 fill-gray-200", %{"fill-red-600" => @status.writable == :no})}/>
-          </div>
-           <% end %>
-           <!-- <div class="h-[27px]">
+    <div class="flex flex-row items-center pt-2 w-[63%] justify-end">
+      <%= if @status.mode == :internal do %>
+        <!-- Crossed DB icon -->
+        <div class="pb-2 pr-1">
+          <.icon
+            id="crossedDataBase"
+            class={
+              classes("w-5 h-[19.5px] fill-gray-200", %{"fill-red-600" => @status.writable == :no})
+            }
+          />
+        </div>
+      <% end %>
+      <%= if @status.mode == :main do %>
+        <!-- DB icon -->
+        <div class="pb-2 pr-1">
+          <.icon
+            id="dataBase"
+            class={
+              classes("w-5 h-[19.5px] fill-gray-200", %{"fill-red-600" => @status.writable == :no})
+            }
+          />
+        </div>
+      <% end %>
+      <%= if @status.mode == :internal_to_main do %>
+        <!-- Blinking or transparent DB icon -->
+        <div class="pb-2 pr-1">
+          <.icon
+            id="dataBase"
+            class={
+              classes("w-5 h-[19.5px] fill-gray-300 animate-pulse", %{
+                "fill-red-600" => @status.writable == :no
+              })
+            }
+          />
+        </div>
+      <% end %>
+      <%= if @status.mode == :main_to_internal do %>
+        <!-- Blinking or transparent Crossed DB icon -->
+        <div class="pb-2 pr-1">
+          <.icon
+            id="crossedDataBase"
+            class={
+              classes("w-5 h-[19.5px] fill-gray-300 animate-pulse", %{
+                "fill-red-600" => @status.writable == :no
+              })
+            }
+          />
+        </div>
+      <% end %>
+      <!-- Saving or downloading icon -->
+      <%= if @status.flags[:backup] do %>
+        <div>
+          <.icon
+            id="backUp"
+            class={classes("w-6 h-6 fill-gray-200", %{"fill-red-600" => @status.writable == :no})}
+          />
+        </div>
+      <% end %>
+      <!-- Syncronization icon, like cirle arrows -->
+      <%= if @status.flags[:replication] do %>
+        <div class="w-[21px] pt-0.5">
+          <.icon
+            id="replication"
+            class={classes("w-6 h-6 fill-gray-200", %{"fill-red-600" => @status.writable == :no})}
+          />
+        </div>
+      <% end %>
+      <!-- <div class="h-[27px]">
               <.icon id="car" class={classes("w-6 h-6 fill-gray-200", %{"fill-red-600" => @status.writable == :no})}/>
             </div> -->
-      </div>
+    </div>
     """
   end
 end

--- a/lib/chat_web/live/main_live/layout/image_gallery.ex
+++ b/lib/chat_web/live/main_live/layout/image_gallery.ex
@@ -5,26 +5,24 @@ defmodule ChatWeb.MainLive.Layout.ImageGallery do
 
   def render(assigns) do
     ~H"""
-      <%= if @mode == assigns[:gallery][:mode] do %>
-        <div id="imageGallery" class="bg-black w-full left-[0%] md:top-[0%] absolute z-30">
+    <%= if @mode == assigns[:gallery][:mode] do %>
+      <div id="imageGallery" class="bg-black w-full left-[0%] md:top-[0%] absolute z-30">
+        <.back_button mode={@mode} />
 
-          <.back_button mode={@mode} />
-
-          <div class="h-screen flex justify-center items-center lg:h-[99vh]">
-            <img
-              phx-click={JS.toggle(to: "#backBtn") |> JS.toggle(to: "#prev") |> JS.toggle(to: "#next") }
-              class="w-auto z-10 max-h-full lg:px-14"
-              src={@gallery[:current][:url]}
-            />
-          </div>
-
-          <div class="button-container flex justify-between absolute bottom-[45%] w-full p-5" >
-            <.prev_button enabled={@gallery[:prev][:url]} mode={@mode}/>
-            <.next_button enabled={@gallery[:next][:url]} mode={@mode} />
-          </div>
-
+        <div class="h-screen flex justify-center items-center lg:h-[99vh]">
+          <img
+            phx-click={JS.toggle(to: "#backBtn") |> JS.toggle(to: "#prev") |> JS.toggle(to: "#next")}
+            class="w-auto z-10 max-h-full lg:px-14"
+            src={@gallery[:current][:url]}
+          />
         </div>
-      <% end %>
+
+        <div class="button-container flex justify-between absolute bottom-[45%] w-full p-5">
+          <.prev_button enabled={@gallery[:prev][:url]} mode={@mode} />
+          <.next_button enabled={@gallery[:next][:url]} mode={@mode} />
+        </div>
+      </div>
+    <% end %>
     """
   end
 
@@ -37,47 +35,67 @@ defmodule ChatWeb.MainLive.Layout.ImageGallery do
     <div id="backBtn" class="w-full h-12 backdrop-blur-md bg-white/10 fixed z-20">
       <button
         class="text-white flex z-20"
-        phx-click={JS.push("#{@mode}/image-gallery/close") |> JS.remove_class("hidden", to: "#chatContent")}
+        phx-click={
+          JS.push("#{@mode}/image-gallery/close") |> JS.remove_class("hidden", to: "#chatContent")
+        }
       >
-      <div class="flex pt-2 pl-2">
-      <svg class="relative top-1" xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="white" viewBox="0 0 24 24">
-          <path d="M16.67 0l2.83 2.829-9.339 9.175 9.339 9.167-2.83 2.829-12.17-11.996z"/>
-        </svg>
-        <p>&nbsp;Back</p>
-      </div>
-
+        <div class="flex pt-2 pl-2">
+          <svg
+            class="relative top-1"
+            xmlns="http://www.w3.org/2000/svg"
+            width="16"
+            height="16"
+            fill="white"
+            viewBox="0 0 24 24"
+          >
+            <path d="M16.67 0l2.83 2.829-9.339 9.175 9.339 9.167-2.83 2.829-12.17-11.996z" />
+          </svg>
+          <p>&nbsp;Back</p>
+        </div>
       </button>
     </div>
-
     """
   end
 
   def prev_button(assigns) do
     ~H"""
-      <button
-        id="prev"
-        class={ @enabled && "z-10" || "invisible"}
-        phx-click={"#{@mode}/image-gallery/prev"}
+    <button
+      id="prev"
+      class={(@enabled && "z-10") || "invisible"}
+      phx-click={"#{@mode}/image-gallery/prev"}
+    >
+      <svg
+        class="a-outline"
+        xmlns="http://www.w3.org/2000/svg"
+        width="24"
+        height="24"
+        fill="white"
+        viewBox="0 0 24 24"
       >
-        <svg class="a-outline" xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="white" viewBox="0 0 24 24">
-          <path d="M16.67 0l2.83 2.829-9.339 9.175 9.339 9.167-2.83 2.829-12.17-11.996z"/>
-        </svg>
-
-      </button>
+        <path d="M16.67 0l2.83 2.829-9.339 9.175 9.339 9.167-2.83 2.829-12.17-11.996z" />
+      </svg>
+    </button>
     """
   end
 
   def next_button(assigns) do
     ~H"""
-      <button
-        id="next"
-        class={ @enabled && "z-10" || "invisible"}
-        phx-click={"#{@mode}/image-gallery/next"}
+    <button
+      id="next"
+      class={(@enabled && "z-10") || "invisible"}
+      phx-click={"#{@mode}/image-gallery/next"}
+    >
+      <svg
+        class="a-outline"
+        xmlns="http://www.w3.org/2000/svg"
+        width="24"
+        height="24"
+        fill="white"
+        viewBox="0 0 24 24"
       >
-        <svg class="a-outline" xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="white" viewBox="0 0 24 24">
-          <path d="M5 3l3.057-3 11.943 12-11.943 12-3.057-3 9-9z"/>
-        </svg>
-      </button>
+        <path d="M5 3l3.057-3 11.943 12-11.943 12-3.057-3 9-9z" />
+      </svg>
+    </button>
     """
   end
 end

--- a/lib/chat_web/live/main_live/layout/message.ex
+++ b/lib/chat_web/live/main_live/layout/message.ex
@@ -54,8 +54,15 @@ defmodule ChatWeb.MainLive.Layout.Message do
       end)
 
     ~H"""
-    <div class="messageBlock flex flex-row px-2 sm:px-8" id={"message-block-#{@msg.id}"} {@dynamic_attrs}>
-      <div class={"m-1 w-full flex " <> if(@is_mine?, do: "justify-end t-#{@chat_type}-mine-message x-mine", else: "justify-start x-peer")} id={"#{@chat_type}-message-#{@msg.id}"}>
+    <div
+      class="messageBlock flex flex-row px-2 sm:px-8"
+      id={"message-block-#{@msg.id}"}
+      {@dynamic_attrs}
+    >
+      <div
+        class={"m-1 w-full flex " <> if(@is_mine?, do: "justify-end t-#{@chat_type}-mine-message x-mine", else: "justify-start x-peer")}
+        id={"#{@chat_type}-message-#{@msg.id}"}
+      >
         <.message
           author={@author}
           chat_type={@chat_type}
@@ -69,7 +76,10 @@ defmodule ChatWeb.MainLive.Layout.Message do
       </div>
 
       <%= unless @export? do %>
-        <input type="checkbox" class="selectCheckbox w-6 h-6 ml-3 mt-3 rounded-full text-purple/90 bg-black/10 border-gray-300 focus:ring-2 t-selectCheckbox" />
+        <input
+          type="checkbox"
+          class="selectCheckbox w-6 h-6 ml-3 mt-3 rounded-full text-purple/90 bg-black/10 border-gray-300 focus:ring-2 t-selectCheckbox"
+        />
       <% end %>
     </div>
     """
@@ -104,7 +114,10 @@ defmodule ChatWeb.MainLive.Layout.Message do
 
   defp message(%{msg: %{type: :file}} = assigns) do
     ~H"""
-    <div id={"message-#{@msg.id}"} class={"#{@color} max-w-xxs sm:max-w-md min-w-[180px] rounded-lg shadow-lg x-download"}>
+    <div
+      id={"message-#{@msg.id}"}
+      class={"#{@color} max-w-xxs sm:max-w-md min-w-[180px] rounded-lg shadow-lg x-download"}
+    >
       <.header author={@author} chat_type={@chat_type} is_mine?={@is_mine?} msg={@msg} />
       <.file msg={@msg} export?={@export?} />
       <.timestamp msg={@msg} timezone={@timezone} />
@@ -116,7 +129,10 @@ defmodule ChatWeb.MainLive.Layout.Message do
     assigns = assign_file(assigns)
 
     ~H"""
-    <div id={"message-#{@msg.id}"} class={"#{@color} max-w-xxs sm:max-w-md min-w-[180px] rounded-lg shadow-lg x-download"}>
+    <div
+      id={"message-#{@msg.id}"}
+      class={"#{@color} max-w-xxs sm:max-w-md min-w-[180px] rounded-lg shadow-lg x-download"}
+    >
       <.header author={@author} chat_type={@chat_type} is_mine?={@is_mine?} msg={@msg} />
       <.timestamp msg={@msg} timezone={@timezone} />
       <.image chat_type={@chat_type} msg={@msg} export?={@export?} file={@file} />
@@ -126,16 +142,19 @@ defmodule ChatWeb.MainLive.Layout.Message do
 
   defp message(%{msg: %{type: :request}} = assigns) do
     ~H"""
-    <div id={"message-#{@msg.id}"} class={"#{@color} max-w-xxs sm:max-w-md min-w-[180px] rounded-lg shadow-lg"}>
+    <div
+      id={"message-#{@msg.id}"}
+      class={"#{@color} max-w-xxs sm:max-w-md min-w-[180px] rounded-lg shadow-lg"}
+    >
       <div class="py-1 px-2">
         <div class="inline-flex">
           <div class="font-bold text-sm text-purple">[<%= short_hash(@author.hash) %>]</div>
           <div class="ml-1 font-bold text-sm text-purple"><%= @author.name %></div>
         </div>
-        <p class="inline-flex">requested access to room </p>
+        <p class="inline-flex">requested access to room</p>
         <div class="inline-flex">
           <div class="font-bold text-sm text-purple">[<%= short_hash(@room.admin_hash) %>]</div>
-          <h1 class="ml-1 font-bold text-sm text-purple" ><%= @room.name %></h1>
+          <h1 class="ml-1 font-bold text-sm text-purple"><%= @room.name %></h1>
         </div>
       </div>
       <.timestamp msg={@msg} timezone={@timezone} />
@@ -156,13 +175,16 @@ defmodule ChatWeb.MainLive.Layout.Message do
       |> assign_new(:room_name, fn %{identity: identity} -> identity.name end)
 
     ~H"""
-    <div id={"message-#{@msg.id}"} class={"#{@color} max-w-xxs sm:max-w-md min-w-[180px] rounded-lg shadow-lg"}>
+    <div
+      id={"message-#{@msg.id}"}
+      class={"#{@color} max-w-xxs sm:max-w-md min-w-[180px] rounded-lg shadow-lg"}
+    >
       <div class="py-1 px-2">
         <div class="inline-flex">
           <div class="font-bold text-sm text-purple">[<%= short_hash(@author.hash) %>]</div>
           <div class="ml-1 font-bold text-sm text-purple"><%= @author.name %></div>
         </div>
-        <p class="inline-flex">wants you to join the room </p>
+        <p class="inline-flex">wants you to join the room</p>
         <div class="inline-flex">
           <div class="font-bold text-sm text-purple">[<%= short_hash(@room_hash) %>]</div>
           <h1 class="ml-1 font-bold text-sm text-purple"><%= @room_name %></h1>
@@ -171,16 +193,22 @@ defmodule ChatWeb.MainLive.Layout.Message do
 
       <%= unless @export? or @is_mine? do %>
         <div class="px-2 my-1 flex items-center justify-between">
-          <button class="w-[49%] h-12 border-0 rounded-lg bg-grayscale text-white"
-           phx-click="dialog/message/accept-room-invite"
-           phx-value-id={@msg.id}
-           phx-value-index={@msg.index}
-          >Accept</button>
-          <button class="w-[49%] h-12 border-0 rounded-lg bg-grayscale text-white"
-           phx-click="dialog/message/accept-room-invite-and-open-room"
-           phx-value-id={@msg.id}
-           phx-value-index={@msg.index}
-          >Accept and Open</button>
+          <button
+            class="w-[49%] h-12 border-0 rounded-lg bg-grayscale text-white"
+            phx-click="dialog/message/accept-room-invite"
+            phx-value-id={@msg.id}
+            phx-value-index={@msg.index}
+          >
+            Accept
+          </button>
+          <button
+            class="w-[49%] h-12 border-0 rounded-lg bg-grayscale text-white"
+            phx-click="dialog/message/accept-room-invite-and-open-room"
+            phx-value-id={@msg.id}
+            phx-value-index={@msg.index}
+          >
+            Accept and Open
+          </button>
         </div>
       <% end %>
 
@@ -191,7 +219,10 @@ defmodule ChatWeb.MainLive.Layout.Message do
 
   defp message(%{msg: %{type: type}} = assigns) when type in [:memo, :text] do
     ~H"""
-    <div id={"message-#{@msg.id}"} class={"#{@color} max-w-xs sm:max-w-md min-w-[180px] rounded-lg shadow-lg"}>
+    <div
+      id={"message-#{@msg.id}"}
+      class={"#{@color} max-w-xs sm:max-w-md min-w-[180px] rounded-lg shadow-lg"}
+    >
       <.header author={@author} chat_type={@chat_type} is_mine?={@is_mine?} msg={@msg} />
       <span class="x-content"><.text msg={@msg} /></span>
       <.timestamp msg={@msg} timezone={@timezone} />
@@ -203,7 +234,10 @@ defmodule ChatWeb.MainLive.Layout.Message do
     assigns = assign_file(assigns)
 
     ~H"""
-    <div id={"message-#{@msg.id}"} class={"#{@color} max-w-xxs sm:max-w-md min-w-[180px] rounded-lg shadow-lg x-download"}>
+    <div
+      id={"message-#{@msg.id}"}
+      class={"#{@color} max-w-xxs sm:max-w-md min-w-[180px] rounded-lg shadow-lg x-download"}
+    >
       <.header author={@author} chat_type={@chat_type} is_mine?={@is_mine?} msg={@msg} />
       <.timestamp msg={@msg} timezone={@timezone} />
       <video src={@file.url} class="a-video" controls />
@@ -213,7 +247,10 @@ defmodule ChatWeb.MainLive.Layout.Message do
 
   defp header(%{export?: true} = assigns) do
     ~H"""
-    <div id={"message-header-" <> @msg.id} class="py-1 px-2 flex items-center justify-between relative">
+    <div
+      id={"message-header-" <> @msg.id}
+      class="py-1 px-2 flex items-center justify-between relative"
+    >
       <div class="flex flex-row">
         <div class="text-sm text-grayscale600">[<%= short_hash(@author.hash) %>]</div>
         <div class="ml-1 font-bold text-sm text-purple"><%= @author.name %></div>
@@ -229,59 +266,91 @@ defmodule ChatWeb.MainLive.Layout.Message do
         <div class="text-sm text-grayscale600">[<%= short_hash(@author.hash) %>]</div>
         <div class="ml-1 font-bold text-sm text-purple"><%= @author.name %></div>
       </div>
-      <button type="button" class="messageActionsDropdownButton hiddenUnderSelection t-message-dropdown" phx-click={open_dropdown("messageActionsDropdown-#{@msg.id}")
-                         |> JS.dispatch("chat:set-dropdown-position", to: "#messageActionsDropdown-#{@msg.id}", detail: %{relativeElementId: "message-#{@msg.id}"})}
+      <button
+        type="button"
+        class="messageActionsDropdownButton hiddenUnderSelection t-message-dropdown"
+        phx-click={
+          open_dropdown("messageActionsDropdown-#{@msg.id}")
+          |> JS.dispatch("chat:set-dropdown-position",
+            to: "#messageActionsDropdown-#{@msg.id}",
+            detail: %{relativeElementId: "message-#{@msg.id}"}
+          )
+        }
       >
-        <.icon id="menu" class="w-4 h-4 flex fill-purple"/>
+        <.icon id="menu" class="w-4 h-4 flex fill-purple" />
       </button>
-      <.dropdown class="messageActionsDropdown " id={"messageActionsDropdown-#{@msg.id}"} >
+      <.dropdown class="messageActionsDropdown " id={"messageActionsDropdown-#{@msg.id}"}>
         <%= if @is_mine? do %>
           <%= if @msg.type in [:text, :memo] do %>
-            <a class="dropdownItem t-edit-message"
-              phx-click={hide_dropdown("messageActionsDropdown-#{@msg.id}") |> JS.push("#{@chat_type}/message/edit")}
+            <a
+              class="dropdownItem t-edit-message"
+              phx-click={
+                hide_dropdown("messageActionsDropdown-#{@msg.id}")
+                |> JS.push("#{@chat_type}/message/edit")
+              }
               phx-value-id={@msg.id}
               phx-value-index={@msg.index}
             >
-              <.icon id="edit" class="w-4 h-4 flex fill-black"/>
+              <.icon id="edit" class="w-4 h-4 flex fill-black" />
               <span>Edit</span>
             </a>
           <% end %>
-          <a class="dropdownItem t-delete-message"
-            phx-click={hide_dropdown("messageActionsDropdown-#{@msg.id}")
-                       |> show_modal("delete-message-popup")
-                       |> JS.set_attribute({"phx-click", hide_modal("delete-message-popup") |> JS.push("#{@chat_type}/delete-messages") |> stringify_commands()}, to: "#delete-message-popup .deleteMessageButton")
-                       |> JS.set_attribute({"phx-value-messages", [%{id: @msg.id, index: "#{@msg.index}"}] |> Jason.encode!}, to: "#delete-message-popup .deleteMessageButton")
-                      }
+          <a
+            class="dropdownItem t-delete-message"
+            phx-click={
+              hide_dropdown("messageActionsDropdown-#{@msg.id}")
+              |> show_modal("delete-message-popup")
+              |> JS.set_attribute(
+                {"phx-click",
+                 hide_modal("delete-message-popup")
+                 |> JS.push("#{@chat_type}/delete-messages")
+                 |> stringify_commands()},
+                to: "#delete-message-popup .deleteMessageButton"
+              )
+              |> JS.set_attribute(
+                {"phx-value-messages", [%{id: @msg.id, index: "#{@msg.index}"}] |> Jason.encode!()},
+                to: "#delete-message-popup .deleteMessageButton"
+              )
+            }
             phx-value-id={@msg.id}
             phx-value-index={@msg.index}
             phx-value-type="dialog-message"
           >
-            <.icon id="delete" class="w-4 h-4 flex fill-black"/>
+            <.icon id="delete" class="w-4 h-4 flex fill-black" />
             <span>Delete</span>
           </a>
         <% end %>
         <a phx-click={hide_dropdown("messageActionsDropdown-#{@msg.id}")} class="dropdownItem">
-          <.icon id="share" class="w-4 h-4 flex fill-black"/>
+          <.icon id="share" class="w-4 h-4 flex fill-black" />
           <span>Share</span>
         </a>
-        <a class="dropdownItem t-select-message"
-           phx-click={hide_dropdown("messageActionsDropdown-#{@msg.id}")
-                     |> JS.push("#{@chat_type}/toggle-messages-select", value: %{action: :on, id: @msg.id, chatType: @chat_type})
-                     |> JS.dispatch("chat:select-message", to: "#message-block-#{@msg.id}", detail: %{chatType: @chat_type})
-                     }>
-          <.icon id="select" class="w-4 h-4 flex fill-black"/>
+        <a
+          class="dropdownItem t-select-message"
+          phx-click={
+            hide_dropdown("messageActionsDropdown-#{@msg.id}")
+            |> JS.push("#{@chat_type}/toggle-messages-select",
+              value: %{action: :on, id: @msg.id, chatType: @chat_type}
+            )
+            |> JS.dispatch("chat:select-message",
+              to: "#message-block-#{@msg.id}",
+              detail: %{chatType: @chat_type}
+            )
+          }
+        >
+          <.icon id="select" class="w-4 h-4 flex fill-black" />
           <span>Select</span>
         </a>
         <%= if @msg.type in [:file, :image, :video] do %>
           <a
             class="dropdownItem"
-            phx-click={hide_dropdown("messageActionsDropdown-#{@msg.id}")
-                      |> JS.push("#{@chat_type}/message/download")
-                      }
+            phx-click={
+              hide_dropdown("messageActionsDropdown-#{@msg.id}")
+              |> JS.push("#{@chat_type}/message/download")
+            }
             phx-value-id={@msg.id}
             phx-value-index={@msg.index}
           >
-            <.icon id="download" class="w-4 h-4 flex fill-black"/>
+            <.icon id="download" class="w-4 h-4 flex fill-black" />
             <span>Download</span>
           </a>
         <% end %>
@@ -301,7 +370,7 @@ defmodule ChatWeb.MainLive.Layout.Message do
 
     ~H"""
     <div class="px-2 text-grayscale600 flex justify-end mr-1" style="font-size: 10px;">
-      <%= @time%>
+      <%= @time %>
     </div>
     """
   end
@@ -377,15 +446,24 @@ defmodule ChatWeb.MainLive.Layout.Message do
 
   defp file_icon(%{export?: true} = assigns) do
     ~H"""
-    <svg id="document" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" class="w-14 h-14 flex fill-black/50">
-      <path fill-rule="evenodd" d="M4 4a2 2 0 012-2h4.586A2 2 0 0112 2.586L15.414 6A2 2 0 0116 7.414V16a2 2 0 01-2 2H6a2 2 0 01-2-2V4z" clip-rule="evenodd" />
+    <svg
+      id="document"
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 20 20"
+      class="w-14 h-14 flex fill-black/50"
+    >
+      <path
+        fill-rule="evenodd"
+        d="M4 4a2 2 0 012-2h4.586A2 2 0 0112 2.586L15.414 6A2 2 0 0116 7.414V16a2 2 0 01-2 2H6a2 2 0 01-2-2V4z"
+        clip-rule="evenodd"
+      />
     </svg>
     """
   end
 
   defp file_icon(assigns) do
     ~H"""
-    <.icon id="document" class="w-14 h-14 flex fill-black/50"/>
+    <.icon id="document" class="w-14 h-14 flex fill-black/50" />
     """
   end
 
@@ -403,13 +481,13 @@ defmodule ChatWeb.MainLive.Layout.Message do
     #  |> JS.remove_class("hidden", to: "#imageGallery")
     #  |> JS.remove_class("overflow-scroll", to: "#chatContent")}
     ~H"""
-      <img
-        class="object-cover overflow-hidden"
-        src={@file.url}
-        phx-click={open_galery(@chat_type)}
-        phx-value-id={@msg.id}
-        phx-value-index={@msg.index}
-      />
+    <img
+      class="object-cover overflow-hidden"
+      src={@file.url}
+      phx-click={open_galery(@chat_type)}
+      phx-value-id={@msg.id}
+      phx-value-index={@msg.index}
+    />
     """
   end
 

--- a/lib/chat_web/live/main_live/page/feed.ex
+++ b/lib/chat_web/live/main_live/page/feed.ex
@@ -47,10 +47,10 @@ defmodule ChatWeb.MainLive.Page.Feed do
       )
 
     ~H"""
-      <div class="border-0 rounded-md bg-white/20 p-2 flex flex-col justify-start" >
-        <span class="text-white"><%= @user && @user.name %> <.action action={@action}/></span>
-        <div class="text-white/70" style="font-size: 10px;"><%= @datetime %></div>
-      </div>
+    <div class="border-0 rounded-md bg-white/20 p-2 flex flex-col justify-start">
+      <span class="text-white"><%= @user && @user.name %> <.action action={@action} /></span>
+      <div class="text-white/70" style="font-size: 10px;"><%= @datetime %></div>
+    </div>
     """
   end
 
@@ -81,15 +81,15 @@ defmodule ChatWeb.MainLive.Page.Feed do
       )
 
     ~H"""
-      <%= @act %>
-      
-      <%= if @to do %>
-        to <%= @to.name %>
-      <% end %> 
+    <%= @act %>
 
-      <%= if @room do %>
-        <%= @room.name %> 
-      <% end %>
+    <%= if @to do %>
+      to <%= @to.name %>
+    <% end %>
+
+    <%= if @room do %>
+      <%= @room.name %>
+    <% end %>
     """
   end
 
@@ -100,7 +100,7 @@ defmodule ChatWeb.MainLive.Page.Feed do
       )
 
     ~H"""
-      <%= @act %>
+    <%= @act %>
     """
   end
 

--- a/lib/chat_web/templates/layout/live.html.heex
+++ b/lib/chat_web/templates/layout/live.html.heex
@@ -1,11 +1,19 @@
 <main class="container">
-  <p class="alert alert-info" role="alert"
+  <p
+    class="alert alert-info"
+    role="alert"
     phx-click="lv:clear-flash"
-    phx-value-key="info"><%= live_flash(@flash, :info) %></p>
+    phx-value-key="info"
+    phx-no-format
+  ><%= live_flash(@flash, :info) %></p>
 
-  <p class="alert alert-danger" role="alert"
+  <p
+    class="alert alert-danger"
+    role="alert"
     phx-click="lv:clear-flash"
-    phx-value-key="error"><%= live_flash(@flash, :error) %></p>
+    phx-value-key="error"
+    phx-no-format
+  ><%= live_flash(@flash, :error) %></p>
 
   <%= @inner_content %>
 </main>

--- a/lib/chat_web/templates/layout/root.html.heex
+++ b/lib/chat_web/templates/layout/root.html.heex
@@ -1,15 +1,21 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <meta charset="utf-8"/>
-    <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <%= csrf_meta_tag() %>
-    <.live_title suffix=" · BuckItUp" >
+    <.live_title suffix=" · BuckItUp">
       <%= assigns[:page_title] || "Chat" %>
     </.live_title>
-    <link phx-track-static rel="stylesheet" href={Routes.static_path(@conn, "/assets/app.css")}/>
-    <script defer phx-track-static type="text/javascript" src={Routes.static_path(@conn, "/assets/app.js")}></script>
+    <link phx-track-static rel="stylesheet" href={Routes.static_path(@conn, "/assets/app.css")} />
+    <script
+      defer
+      phx-track-static
+      type="text/javascript"
+      src={Routes.static_path(@conn, "/assets/app.js")}
+    >
+    </script>
   </head>
   <body>
     <%= @inner_content %>

--- a/lib/chat_web/templates/page/index.html.heex
+++ b/lib/chat_web/templates/page/index.html.heex
@@ -1,5 +1,5 @@
 <section class="phx-hero">
-  <h1><%= gettext "Welcome to %{name}!", name: "Phoenix" %></h1>
+  <h1><%= gettext("Welcome to %{name}!", name: "Phoenix") %></h1>
   <p>Peace of mind from prototype to production</p>
 </section>
 
@@ -14,7 +14,9 @@
         <a href="https://github.com/phoenixframework/phoenix">Source</a>
       </li>
       <li>
-        <a href="https://github.com/phoenixframework/phoenix/blob/v1.6/CHANGELOG.md">v1.6 Changelog</a>
+        <a href="https://github.com/phoenixframework/phoenix/blob/v1.6/CHANGELOG.md">
+          v1.6 Changelog
+        </a>
       </li>
     </ul>
   </article>


### PR DESCRIPTION
I needed to run formatter while refactoring the Message component (PR #69), but it didn't work, so I fixed [`.formatter.exs`](https://github.com/Buckitup-chat/chat/pull/70/files#diff-aad92a030ac915c80a2e0d0204d240fc952893bc87b372dc1b6d485609f27260) file.

All the other changes are from running `mix format` command, except the changes in [`lib/chat_web/templates/layout/live.html.heex`](https://github.com/Buckitup-chat/chat/pull/70/files#diff-57c1bd1fa482024b7b39a5dcb7d430fd49b8b72be003a9fc557396e10850c099) file: added `phx-no-format` attribute to avoid whitespace characters inside flash message containers causing them to be always shown.

I've created this PR to separate the formatter diff from the refactoring and make the review easier.