### PR TITLE
Fix exported messages encoding

### DIFF
--- a/lib/chat_web/controllers/zip_controller.ex
+++ b/lib/chat_web/controllers/zip_controller.ex
@@ -71,7 +71,13 @@ defmodule ChatWeb.ZipController do
 
       exported_messages =
         Stream.concat([
-          [~S(<html><head><meta charset="utf-8" />)],
+          ["<html><head>"],
+          [~S(
+            <meta charset="utf-8" />
+            <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+            <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+            <title>Chat · BuckItUp</title>
+          )],
           ["<style>"],
           style_stream,
           ["</style></head><body>"],

--- a/lib/chat_web/controllers/zip_controller.ex
+++ b/lib/chat_web/controllers/zip_controller.ex
@@ -71,7 +71,7 @@ defmodule ChatWeb.ZipController do
 
       exported_messages =
         Stream.concat([
-          ["<html><head>"],
+          [~S(<html><head><meta charset="utf-8" />)],
           ["<style>"],
           style_stream,
           ["</style></head><body>"],


### PR DESCRIPTION
There was an issue while showing the cyrilic in exported messages in Safari and Brave browsers.
I forgot to add the tag that tells the browser to use the proper encoding. Chrome already has UTF-8 as default encoding, so there was no issue there.