### PR TITLE
Fix CI caching issue

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -11,28 +11,40 @@ permissions:
 
 jobs:
   build:
-
     name: Build and test
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        otp: [ "25.1.1" ]
+        elixir: [ "1.14.1" ]
+
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up Elixir
-      uses: erlef/setup-beam@988e02bfe678367a02564f65ca2e37726dc0268f
-      with:
-        elixir-version: '1.14.1' # Define the elixir version [required]
-        otp-version: '25.1.1' # Define the OTP version [required]
-    - name: Restore dependencies cache
-      uses: actions/cache@v3
-      with:
-        path: deps
-        key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
-        restore-keys: ${{ runner.os }}-mix-
-    - name: Install dependencies
-      run: mix deps.get
-    - name: Compile dependencies
-      run: mix deps.compile
-    - name: Check code
-      run: make ci-check
-    - name: Run tests
-      run: make ci-test
+      - uses: actions/checkout@v3
+
+      - name: Set up Elixir
+        uses: erlef/setup-beam@v1
+        with:
+          elixir-version: ${{ matrix.elixir }}
+          otp-version: ${{ matrix.otp }}
+
+      - uses: actions/cache@v2
+        with:
+          path: |
+            _build
+            deps
+          key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
+          restore-keys: ${{ runner.os }}-mix-
+
+      - name: Install dependencies
+        run: mix deps.get
+
+      - name: Check code
+        env:
+          MIX_ENV: test
+        run: make ci-check
+
+      - name: Run tests
+        env:
+          MIX_ENV: test
+        run: make ci-test

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,1 +1,3 @@
+File.rm_rf!("priv/test_admin_db")
+File.rm_rf!("priv/test_db")
 ExUnit.start()


### PR DESCRIPTION
Deps need to be compiled in the test environment.
`_build` directory needs to be in cache as it contains compiled deps.

After running the tests, test DBs stay in the `priv` directory so I need to remove them before restarting the tests.
This fixes it by removing any existing test DBs before running the tests.