### PR TITLE
Fix file deletion

### DIFF
--- a/lib/chat/content/files.ex
+++ b/lib/chat/content/files.ex
@@ -10,10 +10,14 @@ defmodule Chat.Content.Files do
   def delete({key, _secret}), do: delete(key)
   def delete(key), do: Db.delete(db_key(key))
 
-  def add(data) do
-    key = UUID.uuid4()
+  def add([key, raw_secret, _, _, _, _] = data) do
+    secret = Base.decode64!(raw_secret)
 
-    {key, Storage.cipher_and_store(db_key(key), data)}
+    if Storage.get(db_key(key)) do
+      {key, secret}
+    else
+      {key, Storage.cipher_and_store(db_key(key), data, secret)}
+    end
   end
 
   defp db_key(key), do: {:file, key}

--- a/lib/chat/content/storage.ex
+++ b/lib/chat/content/storage.ex
@@ -4,6 +4,10 @@ defmodule Chat.Content.Storage do
   """
   alias Chat.Db
 
+  def get(db_key) do
+    Db.get(db_key)
+  end
+
   def get_ciphered(db_key, secret) do
     blob = Db.get(db_key)
 
@@ -16,11 +20,15 @@ defmodule Chat.Content.Storage do
     Db.delete(db_key)
   end
 
-  def cipher_and_store(db_key, data) do
-    secret = Enigma.generate_secret()
+  def cipher_and_store(db_key, data, secret) do
     blob = Enigma.cipher(data, secret)
     Db.put(db_key, blob)
 
     secret
+  end
+
+  def cipher_and_store(db_key, data) do
+    secret = Enigma.generate_secret()
+    cipher_and_store(db_key, data, secret)
   end
 end

--- a/lib/chat/dialogs/dialog_messaging.ex
+++ b/lib/chat/dialogs/dialog_messaging.ex
@@ -120,7 +120,7 @@ defmodule Chat.Dialogs.DialogMessaging do
     fn msg, index, key ->
       {index, msg}
       |> read(author, dialog)
-      |> Content.delete([dialog.a_key, dialog.b_key], msg_id)
+      |> Content.delete([dialog.a_key, dialog.b_key], msg.id)
 
       Db.delete(key)
       :ok
@@ -132,7 +132,7 @@ defmodule Chat.Dialogs.DialogMessaging do
     fn msg, index, _key ->
       {index, msg}
       |> read(author, dialog)
-      |> Content.delete([dialog.a_key, dialog.b_key], msg_id)
+      |> Content.delete([dialog.a_key, dialog.b_key], msg.id)
 
       type = DryStorable.type(message)
 
@@ -154,7 +154,7 @@ defmodule Chat.Dialogs.DialogMessaging do
     msg = Db.get(key)
 
     case {msg.is_a_to_b?, public_key == dialog.a_key, public_key == dialog.b_key} do
-      {true, true, false} -> action_fn.(msg, index, key)
+      {true, true, _} -> action_fn.(msg, index, key)
       {false, false, true} -> action_fn.(msg, index, key)
       _ -> nil
     end

--- a/lib/chat_web/controllers/file_controller.ex
+++ b/lib/chat_web/controllers/file_controller.ex
@@ -39,7 +39,7 @@ defmodule ChatWeb.FileController do
   defp render_file(conn, params, opts) do
     with %{"id" => id, "a" => secret} <- params,
          [chunk_key, chunk_secret_raw, _, type, name | _] <-
-           Files.get(id, secret |> Base.url_decode64!()),
+           Files.get(id |> Base.decode16!(case: :lower), secret |> Base.url_decode64!()),
          chunk_secret <- chunk_secret_raw |> Base.decode64!(),
          true <- type |> String.contains?("/") do
       size = ChunkedFiles.size(chunk_key)

--- a/lib/chat_web/live/helpers/uploader.ex
+++ b/lib/chat_web/live/helpers/uploader.ex
@@ -179,7 +179,7 @@ defmodule ChatWeb.LiveHelpers.Uploader do
       entry.client_last_modified
     ]
     |> Enum.join(":")
-    |> Enigma.hash()
+    |> Enigma.short_hash()
   end
 
   defp reader_hash(%{lobby_mode: :chats, peer: %{pub_key: peer_pub_key}}),

--- a/lib/chat_web/live/helpers/uploader.ex
+++ b/lib/chat_web/live/helpers/uploader.ex
@@ -179,7 +179,7 @@ defmodule ChatWeb.LiveHelpers.Uploader do
       entry.client_last_modified
     ]
     |> Enum.join(":")
-    |> Enigma.short_hash()
+    |> Enigma.hash()
   end
 
   defp reader_hash(%{lobby_mode: :chats, peer: %{pub_key: peer_pub_key}}),

--- a/lib/chat_web/live/main_live/layout/message.ex
+++ b/lib/chat_web/live/main_live/layout/message.ex
@@ -546,7 +546,7 @@ defmodule ChatWeb.MainLive.Layout.Message do
   defp assign_file(assigns), do: assign(assigns, :file, nil)
 
   defp get_file_url(id, secret) do
-    "/get/file/#{id}?a=#{Base.url_encode64(secret)}"
+    ~p"/get/file/#{Base.encode16(id, case: :lower)}?a=#{Base.url_encode64(secret)}"
   end
 
   attr :export?, :boolean, required: true, doc: "embed file icon SVG?"

--- a/lib/chat_web/live/main_live/layout/message.ex
+++ b/lib/chat_web/live/main_live/layout/message.ex
@@ -539,21 +539,14 @@ defmodule ChatWeb.MainLive.Layout.Message do
     assign(assigns, :file, %{
       name: name,
       size: size,
-      url: get_file_url(:file, id, secret)
+      url: get_file_url(id, secret)
     })
   end
 
   defp assign_file(assigns), do: assign(assigns, :file, nil)
 
-  defp get_file_url(type, id, secret) do
-    file_type =
-      if type == :image do
-        "image"
-      else
-        "file"
-      end
-
-    "/get/#{file_type}/#{id}?a=#{Base.url_encode64(secret)}"
+  defp get_file_url(id, secret) do
+    "/get/file/#{id}?a=#{Base.url_encode64(secret)}"
   end
 
   attr :export?, :boolean, required: true, doc: "embed file icon SVG?"

--- a/lib/chat_web/live/main_live/page/dialog.ex
+++ b/lib/chat_web/live/main_live/page/dialog.ex
@@ -209,17 +209,6 @@ defmodule ChatWeb.MainLive.Page.Dialog do
     |> assign(:edit_message_id, nil)
   end
 
-  def delete_message(
-        %{assigns: %{me: me, dialog: dialog, monotonic_offset: time_offset}} = socket,
-        {index, msg_id}
-      ) do
-    time = Chat.Time.monotonic_to_unix(time_offset)
-    Dialogs.delete(dialog, me, {index, msg_id})
-    broadcast_message_deleted(msg_id, dialog, me, time)
-
-    socket
-  end
-
   def delete_messages(
         %{assigns: %{me: me, dialog: dialog, monotonic_offset: time_offset}} = socket,
         %{

--- a/lib/chat_web/live/main_live/page/room.ex
+++ b/lib/chat_web/live/main_live/page/room.ex
@@ -249,24 +249,6 @@ defmodule ChatWeb.MainLive.Page.Room do
     |> assign(:edit_message_id, nil)
   end
 
-  def delete_message(
-        %{
-          assigns: %{
-            me: me,
-            room_identity: room_identity,
-            room: room,
-            monotonic_offset: time_offset
-          }
-        } = socket,
-        {index, msg_id}
-      ) do
-    time = Chat.Time.monotonic_to_unix(time_offset)
-    Rooms.delete_message({index, msg_id}, room_identity, me)
-    broadcast_deleted_message(msg_id, room.pub_key, me, time)
-
-    socket
-  end
-
   def approve_request(%{assigns: %{room_identity: room_identity}} = socket, user_key) do
     Rooms.approve_request(room_identity |> Identity.pub_key(), user_key, room_identity)
 

--- a/mix.exs
+++ b/mix.exs
@@ -12,7 +12,7 @@ defmodule Chat.MixProject do
       aliases: aliases(),
       deps: deps(),
       test_coverage: [
-        summary: [threshold: 58]
+        summary: [threshold: 59]
       ],
       releases: [
         chat: [

--- a/test/chat/db/scope/key_scope_test.exs
+++ b/test/chat/db/scope/key_scope_test.exs
@@ -95,6 +95,8 @@ defmodule Chat.Db.Scope.KeyScopeTest do
         |> Map.fetch!(:content)
         |> Utils.StorageId.from_json_to_key()
 
+      ChangeTracker.await()
+
       Rooms.add_request(first_room_key, charlie, 1)
       Rooms.approve_request(first_room_key, charlie_key, room_identity, [])
 

--- a/test/chat/room_test.exs
+++ b/test/chat/room_test.exs
@@ -95,6 +95,8 @@ defmodule Chat.Rooms.RoomTest do
 
     assert room_identity == %{decrypted_identity | name: room_identity.name}
 
+    ChangeTracker.await()
+
     refute is_nil(room_identity)
 
     room = room_identity |> Rooms.clear_approved_request(bob)

--- a/test/chat_web/live/helpers/uploader_test.exs
+++ b/test/chat_web/live/helpers/uploader_test.exs
@@ -7,6 +7,7 @@ defmodule ChatWeb.Helpers.UploaderTest do
 
   alias Chat.ChunkedFiles
   alias Chat.Content.Files
+  alias Chat.Db.ChangeTracker
   alias Chat.Dialogs
   alias Chat.Dialogs.{Dialog, PrivateMessage}
   alias Chat.Rooms
@@ -14,6 +15,7 @@ defmodule ChatWeb.Helpers.UploaderTest do
   alias Chat.Upload.{Upload, UploadIndex, UploadMetadata, UploadStatus}
   alias Chat.Utils.StorageId
   alias ChatWeb.LiveHelpers.Uploader
+  alias ChatWeb.MainLive.Index
   alias Phoenix.LiveView.{Socket, UploadConfig, UploadEntry, Utils}
 
   describe "allow_file_upload/3" do
@@ -406,16 +408,47 @@ defmodule ChatWeb.Helpers.UploaderTest do
       refute Map.get(socket.assigns.uploads_metadata, existing_entry.uuid)
       refute Map.get(socket.assigns.uploads_metadata, uuid)
 
-      retry_until(1_000, fn ->
-        assert [%PrivateMessage{} = message_1, %PrivateMessage{} = message_2] =
-                 Dialogs.read(socket.assigns.dialog, socket.assigns.me)
+      ChangeTracker.await()
 
-        assert message_1.type == :image
-        assert {id_1, secret_1} = StorageId.from_json(message_1.content)
-        assert message_2.type == :image
-        assert {id_2, secret_2} = StorageId.from_json(message_2.content)
-        assert Files.get(id_1, secret_1) == Files.get(id_2, secret_2)
-      end)
+      assert [%PrivateMessage{} = message_1, %PrivateMessage{} = message_2] =
+               Dialogs.read(socket.assigns.dialog, socket.assigns.me)
+
+      assert message_1.type == :image
+      assert credentials_1 = StorageId.from_json(message_1.content)
+      assert message_2.type == :image
+      assert credentials_2 = StorageId.from_json(message_2.content)
+      assert Files.get(credentials_1) == Files.get(credentials_2)
+
+      state = :sys.get_state(view.pid)
+      socket = state.socket
+
+      Index.handle_event(
+        "dialog/delete-messages",
+        %{
+          "messages" =>
+            Jason.encode!([%{id: message_1.id, index: Integer.to_string(message_1.index)}])
+        },
+        socket
+      )
+
+      ChangeTracker.await()
+
+      assert Files.get(credentials_1)
+      assert Files.get(credentials_2)
+
+      Index.handle_event(
+        "dialog/delete-messages",
+        %{
+          "messages" =>
+            Jason.encode!([%{id: message_2.id, index: Integer.to_string(message_2.index)}])
+        },
+        socket
+      )
+
+      ChangeTracker.await()
+
+      refute Files.get(credentials_1)
+      refute Files.get(credentials_2)
     end
 
     test "when file has already been uploaded to the room commands uploader to skip", %{
@@ -442,19 +475,50 @@ defmodule ChatWeb.Helpers.UploaderTest do
       refute Map.get(socket.assigns.uploads_metadata, existing_entry.uuid)
       refute Map.get(socket.assigns.uploads_metadata, uuid)
 
-      retry_until(1_000, fn ->
-        assert [%PlainMessage{} = message_1, %PlainMessage{} = message_2] =
-                 Rooms.read(
-                   socket.assigns.room,
-                   socket.assigns.room_identity
-                 )
+      ChangeTracker.await()
 
-        assert message_1.type == :image
-        assert {id_1, secret_1} = StorageId.from_json(message_1.content)
-        assert message_2.type == :image
-        assert {id_2, secret_2} = StorageId.from_json(message_2.content)
-        assert Files.get(id_1, secret_1) == Files.get(id_2, secret_2)
-      end)
+      assert [%PlainMessage{} = message_1, %PlainMessage{} = message_2] =
+               Rooms.read(
+                 socket.assigns.room,
+                 socket.assigns.room_identity
+               )
+
+      assert message_1.type == :image
+      assert credentials_1 = StorageId.from_json(message_1.content)
+      assert message_2.type == :image
+      assert credentials_2 = StorageId.from_json(message_2.content)
+      assert Files.get(credentials_1) == Files.get(credentials_2)
+
+      state = :sys.get_state(view.pid)
+      socket = state.socket
+
+      Index.handle_event(
+        "room/delete-messages",
+        %{
+          "messages" =>
+            Jason.encode!([%{id: message_1.id, index: Integer.to_string(message_1.index)}])
+        },
+        socket
+      )
+
+      ChangeTracker.await()
+
+      assert Files.get(credentials_1)
+      assert Files.get(credentials_2)
+
+      Index.handle_event(
+        "room/delete-messages",
+        %{
+          "messages" =>
+            Jason.encode!([%{id: message_2.id, index: Integer.to_string(message_2.index)}])
+        },
+        socket
+      )
+
+      ChangeTracker.await()
+
+      refute Files.get(credentials_1)
+      refute Files.get(credentials_2)
     end
   end
 

--- a/test/support/fake_data.ex
+++ b/test/support/fake_data.ex
@@ -5,7 +5,7 @@ defmodule Support.FakeData do
 
   def file do
     key = UUID.uuid4()
-    secret = "12312414132341"
+    secret = Enigma.generate_secret()
 
     %{client_size: 123, client_type: "audio/mp3", client_name: "Some file.ext"}
     |> Messages.File.new(key, secret)
@@ -13,7 +13,7 @@ defmodule Support.FakeData do
 
   def image(name) do
     key = UUID.uuid4()
-    secret = "12312414132341"
+    secret = Enigma.generate_secret()
 
     %{client_size: 123, client_type: "image/jpeg", client_name: name}
     |> Messages.File.new(key, secret)


### PR DESCRIPTION
We couldn't delete records from the `FileIndex` because each message had a different key for the same file.
Now we use the same key which makes it possible to check for other instances of the same file (https://github.com/Buckitup-chat/chat/pull/202/files#diff-d938b8e0e8e238103c8e7fed6ff3493af3705628bad718c89060fa6142c58f3aR13).

Also, files couldn't be deleted from the dialogs at all because we were sending incorrect message ID (https://github.com/Buckitup-chat/chat/pull/202/files#diff-9fbc183bef396d8bacd542491a315bacb688c57e0c3ee5f7cdf16fc945d9493fR123 and https://github.com/Buckitup-chat/chat/pull/202/files#diff-9fbc183bef396d8bacd542491a315bacb688c57e0c3ee5f7cdf16fc945d9493fR135).
Besides that, content wasn't being deleted from My notes (https://github.com/Buckitup-chat/chat/pull/202/files#diff-9fbc183bef396d8bacd542491a315bacb688c57e0c3ee5f7cdf16fc945d9493fR157).